### PR TITLE
Add playbook manager pass 1

### DIFF
--- a/cmd/apps/playbook-manager-glazed/main.go
+++ b/cmd/apps/playbook-manager-glazed/main.go
@@ -108,6 +108,10 @@ func main() {
 			initStorage()
 			return playbook.NewGetMetadataCommand(storage)
 		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewRefreshCommand(storage)
+		},
 	}
 
 	// Convert commands to Cobra commands and add to root

--- a/cmd/apps/playbook-manager-glazed/main.go
+++ b/cmd/apps/playbook-manager-glazed/main.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/help"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/go-go-golems/go-go-labs/pkg/playbook"
+)
+
+func main() {
+	var (
+		logLevel string
+		dbPath   string
+	)
+
+	rootCmd := &cobra.Command{
+		Use:   "pb",
+		Short: "Playbook Manager - manage contextual documents for LLMs",
+		Long:  `Playbook Manager is a CLI tool for managing playbooks and collections of contextual documents that can be passed to LLMs.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Set up logging
+			level, err := zerolog.ParseLevel(logLevel)
+			if err != nil {
+				level = zerolog.InfoLevel
+			}
+			zerolog.SetGlobalLevel(level)
+			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+		},
+	}
+
+	// Global flags
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path (default: ~/.playbooks/registry.db)")
+
+	// Initialize help system
+	helpSystem := help.NewHelpSystem()
+	helpSystem.SetupCobraRootCommand(rootCmd)
+
+	// Initialize storage
+	var storage *playbook.Storage
+	initStorage := func() {
+		if storage != nil {
+			return
+		}
+
+		if dbPath == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to get user home directory")
+			}
+			dbPath = filepath.Join(homeDir, ".playbooks", "registry.db")
+		}
+
+		var err error
+		storage, err = playbook.NewStorage(dbPath)
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to initialize storage")
+		}
+	}
+
+	// Create commands
+	commands := []func() (cmds.Command, error){
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewRegisterCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewCreateCollectionCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewListCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewSearchCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewShowCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewDeployCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewAddToCollectionCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewRemoveCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewSetMetadataCommand(storage)
+		},
+		func() (cmds.Command, error) {
+			initStorage()
+			return playbook.NewGetMetadataCommand(storage)
+		},
+	}
+
+	// Convert commands to Cobra commands and add to root
+	for _, cmdFunc := range commands {
+		cmd, err := cmdFunc()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating command: %v\n", err)
+			os.Exit(1)
+		}
+
+		cobraCmd, err := cli.BuildCobraCommandFromCommand(cmd)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error building Cobra command: %v\n", err)
+			os.Exit(1)
+		}
+
+		rootCmd.AddCommand(cobraCmd)
+	}
+
+	// Add cleanup
+	cobra.OnFinalize(func() {
+		if storage != nil {
+			storage.Close()
+		}
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/cmd/apps/playbook-manager/commands.go
+++ b/cmd/apps/playbook-manager/commands.go
@@ -1,0 +1,745 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/go-go-golems/go-go-labs/pkg/playbook"
+)
+
+// registerCmd registers a playbook from file or URL
+func registerCmd() *cobra.Command {
+	var (
+		title       string
+		description string
+		summary     string
+		metadata    []string
+		tags        []string
+		filename    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "register <path|url>",
+		Short: "Register a playbook from file or URL",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			source := args[0]
+
+			// Read content from file or URL
+			var content string
+			var canonicalURL *string
+			var err error
+
+			if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+				content, err = fetchURL(source)
+				canonicalURL = &source
+			} else {
+				content, err = readFile(source)
+				if filename == "" {
+					filename = filepath.Base(source)
+				}
+			}
+			if err != nil {
+				return fmt.Errorf("failed to read content: %w", err)
+			}
+
+			// Create entity
+			entity := &playbook.Entity{
+				Type:         playbook.TypePlaybook,
+				Title:        title,
+				Description:  description,
+				Summary:      summary,
+				CanonicalURL: canonicalURL,
+				Content:      &content,
+				Tags:         tags,
+				LastFetched:  timePtr(time.Now()),
+			}
+
+			if filename != "" {
+				entity.Filename = &filename
+			}
+
+			// Parse metadata
+			if len(metadata) > 0 {
+				entity.Metadata = make(map[string]string)
+				for _, meta := range metadata {
+					parts := strings.SplitN(meta, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid metadata format: %s (expected key=value)", meta)
+					}
+					entity.Metadata[parts[0]] = parts[1]
+				}
+			}
+
+			if err := storage.CreateEntity(entity); err != nil {
+				return fmt.Errorf("failed to create entity: %w", err)
+			}
+
+			fmt.Printf("Registered playbook: %s (slug: %s)\n", entity.Title, entity.Slug)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Title of the playbook")
+	cmd.Flags().StringVar(&description, "description", "", "Description of the playbook")
+	cmd.Flags().StringVar(&summary, "summary", "", "Summary of the playbook")
+	cmd.Flags().StringSliceVar(&metadata, "meta", nil, "Metadata in key=value format (can be used multiple times)")
+	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Tags (comma-separated)")
+	cmd.Flags().StringVar(&filename, "filename", "", "Override filename")
+
+	cmd.MarkFlagRequired("title")
+
+	return cmd
+}
+
+// createCmd creates a new collection
+func createCmd() *cobra.Command {
+	var (
+		title       string
+		description string
+		summary     string
+		metadata    []string
+		tags        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create collection <name>",
+		Short: "Create a new collection",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if args[0] != "collection" {
+				return fmt.Errorf("only 'collection' type is supported")
+			}
+
+			name := args[1]
+			if title == "" {
+				title = name
+			}
+
+			entity := &playbook.Entity{
+				Type:        playbook.TypeCollection,
+				Title:       title,
+				Description: description,
+				Summary:     summary,
+				Tags:        tags,
+			}
+
+			// Parse metadata
+			if len(metadata) > 0 {
+				entity.Metadata = make(map[string]string)
+				for _, meta := range metadata {
+					parts := strings.SplitN(meta, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid metadata format: %s (expected key=value)", meta)
+					}
+					entity.Metadata[parts[0]] = parts[1]
+				}
+			}
+
+			if err := storage.CreateEntity(entity); err != nil {
+				return fmt.Errorf("failed to create collection: %w", err)
+			}
+
+			fmt.Printf("Created collection: %s (slug: %s)\n", entity.Title, entity.Slug)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Display title (defaults to name)")
+	cmd.Flags().StringVar(&description, "description", "", "Description of the collection")
+	cmd.Flags().StringVar(&summary, "summary", "", "Summary of the collection")
+	cmd.Flags().StringSliceVar(&metadata, "meta", nil, "Metadata in key=value format (can be used multiple times)")
+	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Tags (comma-separated)")
+
+	return cmd
+}
+
+// listCmd lists entities with optional filters
+func listCmd() *cobra.Command {
+	var (
+		entityType string
+		tags       []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List entities with optional filters",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var typeFilter *playbook.EntityType
+			if entityType != "" {
+				switch entityType {
+				case "playbook":
+					t := playbook.TypePlaybook
+					typeFilter = &t
+				case "collection":
+					t := playbook.TypeCollection
+					typeFilter = &t
+				default:
+					return fmt.Errorf("invalid type: %s (must be 'playbook' or 'collection')", entityType)
+				}
+			}
+
+			entities, err := storage.ListEntities(typeFilter, tags)
+			if err != nil {
+				return fmt.Errorf("failed to list entities: %w", err)
+			}
+
+			for _, entity := range entities {
+				fmt.Printf("%s (%s) - %s\n", entity.Slug, entity.Type, entity.Title)
+				if entity.Summary != "" {
+					fmt.Printf("  %s\n", entity.Summary)
+				}
+				if len(entity.Tags) > 0 {
+					fmt.Printf("  Tags: %s\n", strings.Join(entity.Tags, ", "))
+				}
+				fmt.Println()
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&entityType, "type", "", "Filter by type (playbook or collection)")
+	cmd.Flags().StringSliceVar(&tags, "tags", nil, "Filter by tags (comma-separated)")
+
+	return cmd
+}
+
+// searchCmd searches entities
+func searchCmd() *cobra.Command {
+	var entityType string
+
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Search entities by query string",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			query := args[0]
+
+			var typeFilter *playbook.EntityType
+			if entityType != "" {
+				switch entityType {
+				case "playbook":
+					t := playbook.TypePlaybook
+					typeFilter = &t
+				case "collection":
+					t := playbook.TypeCollection
+					typeFilter = &t
+				default:
+					return fmt.Errorf("invalid type: %s (must be 'playbook' or 'collection')", entityType)
+				}
+			}
+
+			entities, err := storage.SearchEntities(query, typeFilter)
+			if err != nil {
+				return fmt.Errorf("failed to search entities: %w", err)
+			}
+
+			for _, entity := range entities {
+				fmt.Printf("%s (%s) - %s\n", entity.Slug, entity.Type, entity.Title)
+				if entity.Summary != "" {
+					fmt.Printf("  %s\n", entity.Summary)
+				}
+				if len(entity.Tags) > 0 {
+					fmt.Printf("  Tags: %s\n", strings.Join(entity.Tags, ", "))
+				}
+				fmt.Println()
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&entityType, "type", "", "Filter by type (playbook or collection)")
+
+	return cmd
+}
+
+// showCmd shows detailed information about an entity
+func showCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <slug>",
+		Short: "Show detailed information about an entity",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			fmt.Printf("Slug: %s\n", entity.Slug)
+			fmt.Printf("Type: %s\n", entity.Type)
+			fmt.Printf("Title: %s\n", entity.Title)
+			if entity.Description != "" {
+				fmt.Printf("Description: %s\n", entity.Description)
+			}
+			if entity.Summary != "" {
+				fmt.Printf("Summary: %s\n", entity.Summary)
+			}
+			if entity.CanonicalURL != nil {
+				fmt.Printf("URL: %s\n", *entity.CanonicalURL)
+			}
+			if entity.Filename != nil {
+				fmt.Printf("Filename: %s\n", *entity.Filename)
+			}
+			if len(entity.Tags) > 0 {
+				fmt.Printf("Tags: %s\n", strings.Join(entity.Tags, ", "))
+			}
+			if entity.LastFetched != nil {
+				fmt.Printf("Last Fetched: %s\n", entity.LastFetched.Format(time.RFC3339))
+			}
+			fmt.Printf("Created: %s\n", entity.CreatedAt.Format(time.RFC3339))
+
+			// Show metadata
+			if len(entity.Metadata) > 0 {
+				fmt.Println("\nMetadata:")
+				for key, value := range entity.Metadata {
+					fmt.Printf("  %s: %s\n", key, value)
+				}
+			}
+
+			// Show collection members if it's a collection
+			if entity.Type == playbook.TypeCollection {
+				members, err := storage.GetCollectionMembers(entity.ID)
+				if err != nil {
+					log.Warn().Err(err).Msg("Failed to get collection members")
+				} else if len(members) > 0 {
+					fmt.Println("\nMembers:")
+					for _, member := range members {
+						memberEntity, err := storage.GetEntityByID(member.MemberID)
+						if err != nil {
+							fmt.Printf("  ID %d (error loading details)\n", member.MemberID)
+						} else {
+							fmt.Printf("  %s (%s) - %s\n", memberEntity.Slug, memberEntity.Type, memberEntity.Title)
+							if member.RelativePath != nil {
+								fmt.Printf("    Path: %s\n", *member.RelativePath)
+							}
+						}
+					}
+				}
+			}
+
+			// Show content if it's a playbook
+			if entity.Type == playbook.TypePlaybook && entity.Content != nil {
+				fmt.Println("\nContent:")
+				fmt.Println(*entity.Content)
+			}
+
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+// addCmd adds entities to collections
+func addCmd() *cobra.Command {
+	var relativePath string
+
+	cmd := &cobra.Command{
+		Use:   "add <collection-slug> <member-slug>",
+		Short: "Add a member to a collection",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			collectionSlug := args[0]
+			memberSlug := args[1]
+
+			collection, err := storage.GetEntityBySlug(collectionSlug)
+			if err != nil {
+				return fmt.Errorf("failed to get collection: %w", err)
+			}
+			if collection.Type != playbook.TypeCollection {
+				return fmt.Errorf("%s is not a collection", collectionSlug)
+			}
+
+			member, err := storage.GetEntityBySlug(memberSlug)
+			if err != nil {
+				return fmt.Errorf("failed to get member: %w", err)
+			}
+
+			var relPath *string
+			if relativePath != "" {
+				relPath = &relativePath
+			}
+
+			if err := storage.AddToCollection(collection.ID, member.ID, relPath); err != nil {
+				return fmt.Errorf("failed to add to collection: %w", err)
+			}
+
+			fmt.Printf("Added %s to collection %s\n", member.Title, collection.Title)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&relativePath, "path", "", "Relative path within collection")
+
+	return cmd
+}
+
+// removeCmd removes entities from collections or deletes entities
+func removeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "remove <collection-slug> <member-slug> | remove <entity-slug>",
+		Short: "Remove a member from a collection or delete an entity",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 1 {
+				// Delete entity
+				entitySlug := args[0]
+				entity, err := storage.GetEntityBySlug(entitySlug)
+				if err != nil {
+					return fmt.Errorf("failed to get entity: %w", err)
+				}
+
+				if err := storage.DeleteEntity(entity.ID); err != nil {
+					return fmt.Errorf("failed to delete entity: %w", err)
+				}
+
+				fmt.Printf("Deleted %s (%s)\n", entity.Title, entity.Type)
+				return nil
+			}
+
+			if len(args) == 2 {
+				// Remove from collection
+				collectionSlug := args[0]
+				memberSlug := args[1]
+
+				collection, err := storage.GetEntityBySlug(collectionSlug)
+				if err != nil {
+					return fmt.Errorf("failed to get collection: %w", err)
+				}
+				if collection.Type != playbook.TypeCollection {
+					return fmt.Errorf("%s is not a collection", collectionSlug)
+				}
+
+				member, err := storage.GetEntityBySlug(memberSlug)
+				if err != nil {
+					return fmt.Errorf("failed to get member: %w", err)
+				}
+
+				if err := storage.RemoveFromCollection(collection.ID, member.ID); err != nil {
+					return fmt.Errorf("failed to remove from collection: %w", err)
+				}
+
+				fmt.Printf("Removed %s from collection %s\n", member.Title, collection.Title)
+				return nil
+			}
+
+			return fmt.Errorf("invalid number of arguments")
+		},
+	}
+
+	return cmd
+}
+
+// metaCmd manages metadata
+func metaCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "meta",
+		Short: "Manage entity metadata",
+	}
+
+	// meta set
+	setCmd := &cobra.Command{
+		Use:   "set <slug> <key> <value>",
+		Short: "Set metadata for an entity",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+			key := args[1]
+			value := args[2]
+
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			if err := storage.SetMetadata(entity.ID, key, value); err != nil {
+				return fmt.Errorf("failed to set metadata: %w", err)
+			}
+
+			fmt.Printf("Set metadata %s=%s for %s\n", key, value, entity.Title)
+			return nil
+		},
+	}
+
+	// meta get
+	getCmd := &cobra.Command{
+		Use:   "get <slug> [key]",
+		Short: "Get metadata for an entity",
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			metadata, err := storage.GetMetadata(entity.ID)
+			if err != nil {
+				return fmt.Errorf("failed to get metadata: %w", err)
+			}
+
+			if len(args) == 2 {
+				// Get specific key
+				key := args[1]
+				if value, exists := metadata[key]; exists {
+					fmt.Println(value)
+				} else {
+					return fmt.Errorf("metadata key %s not found", key)
+				}
+			} else {
+				// Get all metadata
+				for key, value := range metadata {
+					fmt.Printf("%s: %s\n", key, value)
+				}
+			}
+
+			return nil
+		},
+	}
+
+	// meta remove
+	removeCmd := &cobra.Command{
+		Use:   "remove <slug> <key>",
+		Short: "Remove metadata from an entity",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+			key := args[1]
+
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			if err := storage.DeleteMetadata(entity.ID, key); err != nil {
+				return fmt.Errorf("failed to remove metadata: %w", err)
+			}
+
+			fmt.Printf("Removed metadata %s from %s\n", key, entity.Title)
+			return nil
+		},
+	}
+
+	cmd.AddCommand(setCmd, getCmd, removeCmd)
+	return cmd
+}
+
+// deployCmd deploys entities to directories
+func deployCmd() *cobra.Command {
+	var filenameOverride string
+
+	cmd := &cobra.Command{
+		Use:   "deploy <slug> <target-directory>",
+		Short: "Deploy an entity to a target directory",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			slug := args[0]
+			targetDir := args[1]
+
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			if err := os.MkdirAll(targetDir, 0755); err != nil {
+				return fmt.Errorf("failed to create target directory: %w", err)
+			}
+
+			if entity.Type == playbook.TypePlaybook {
+				// Deploy single playbook
+				filename := filenameOverride
+				if filename == "" && entity.Filename != nil {
+					filename = *entity.Filename
+				}
+				if filename == "" {
+					filename = entity.Slug + ".md"
+				}
+
+				filePath := filepath.Join(targetDir, filename)
+				if err := os.WriteFile(filePath, []byte(*entity.Content), 0644); err != nil {
+					return fmt.Errorf("failed to write file: %w", err)
+				}
+
+				fmt.Printf("Deployed playbook %s to %s\n", entity.Title, filePath)
+			} else {
+				// Deploy collection
+				members, err := storage.GetCollectionMembers(entity.ID)
+				if err != nil {
+					return fmt.Errorf("failed to get collection members: %w", err)
+				}
+
+				for _, member := range members {
+					memberEntity, err := storage.GetEntityByID(member.MemberID)
+					if err != nil {
+						log.Warn().Err(err).Int64("member_id", member.MemberID).Msg("Failed to load member")
+						continue
+					}
+
+					if memberEntity.Type == playbook.TypePlaybook && memberEntity.Content != nil {
+						filename := ""
+						if member.RelativePath != nil {
+							filename = *member.RelativePath
+						} else if memberEntity.Filename != nil {
+							filename = *memberEntity.Filename
+						} else {
+							filename = memberEntity.Slug + ".md"
+						}
+
+						filePath := filepath.Join(targetDir, filename)
+						
+						// Create parent directory if needed
+						if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+							log.Warn().Err(err).Str("path", filepath.Dir(filePath)).Msg("Failed to create directory")
+							continue
+						}
+
+						if err := os.WriteFile(filePath, []byte(*memberEntity.Content), 0644); err != nil {
+							log.Warn().Err(err).Str("path", filePath).Msg("Failed to write file")
+							continue
+						}
+
+						fmt.Printf("Deployed %s to %s\n", memberEntity.Title, filePath)
+					}
+				}
+
+				fmt.Printf("Deployed collection %s to %s\n", entity.Title, targetDir)
+			}
+
+			// Record deployment
+			if err := storage.RecordDeployment(entity.ID, targetDir); err != nil {
+				log.Warn().Err(err).Msg("Failed to record deployment")
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&filenameOverride, "filename", "", "Override filename for playbook deployment")
+
+	return cmd
+}
+
+// updateCmd updates playbooks from their sources
+func updateCmd() *cobra.Command {
+	var updateAll bool
+
+	cmd := &cobra.Command{
+		Use:   "update <slug> | --all",
+		Short: "Update playbooks from their canonical sources",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if updateAll {
+				// Update all playbooks with canonical URLs
+				playbookType := playbook.TypePlaybook
+				playbooks, err := storage.ListEntities(&playbookType, nil)
+				if err != nil {
+					return fmt.Errorf("failed to list playbooks: %w", err)
+				}
+
+				for _, pb := range playbooks {
+					if pb.CanonicalURL != nil {
+						if err := updatePlaybook(pb); err != nil {
+							log.Warn().Err(err).Str("slug", pb.Slug).Msg("Failed to update playbook")
+						} else {
+							fmt.Printf("Updated %s\n", pb.Title)
+						}
+					}
+				}
+				return nil
+			}
+
+			if len(args) != 1 {
+				return fmt.Errorf("either provide a slug or use --all")
+			}
+
+			slug := args[0]
+			entity, err := storage.GetEntityBySlug(slug)
+			if err != nil {
+				return fmt.Errorf("failed to get entity: %w", err)
+			}
+
+			if entity.Type != playbook.TypePlaybook {
+				return fmt.Errorf("%s is not a playbook", slug)
+			}
+
+			if entity.CanonicalURL == nil {
+				return fmt.Errorf("playbook %s has no canonical URL", slug)
+			}
+
+			if err := updatePlaybook(entity); err != nil {
+				return fmt.Errorf("failed to update playbook: %w", err)
+			}
+
+			fmt.Printf("Updated %s\n", entity.Title)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&updateAll, "all", false, "Update all playbooks")
+
+	return cmd
+}
+
+// Helper functions
+
+func fetchURL(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+func readFile(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+func updatePlaybook(entity *playbook.Entity) error {
+	if entity.CanonicalURL == nil {
+		return fmt.Errorf("no canonical URL")
+	}
+
+	content, err := fetchURL(*entity.CanonicalURL)
+	if err != nil {
+		return err
+	}
+
+	// Update content and last fetched time
+	entity.Content = &content
+	now := time.Now()
+	entity.LastFetched = &now
+
+	// Here we would need an update method in storage
+	// For now, this is a placeholder
+	log.Info().Str("slug", entity.Slug).Msg("Would update playbook content")
+
+	return nil
+}

--- a/cmd/apps/playbook-manager/main.go
+++ b/cmd/apps/playbook-manager/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/cobra"
+
+	"github.com/go-go-golems/go-go-labs/pkg/playbook"
+)
+
+var (
+	storage   *playbook.Storage
+	logLevel  string
+	dbPath    string
+)
+
+func main() {
+	rootCmd := &cobra.Command{
+		Use:   "pb",
+		Short: "Playbook Manager - manage contextual documents for LLMs",
+		Long:  `Playbook Manager is a CLI tool for managing playbooks and collections of contextual documents that can be passed to LLMs.`,
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// Set up logging
+			level, err := zerolog.ParseLevel(logLevel)
+			if err != nil {
+				level = zerolog.InfoLevel
+			}
+			zerolog.SetGlobalLevel(level)
+			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+
+			// Initialize storage
+			if dbPath == "" {
+				homeDir, err := os.UserHomeDir()
+				if err != nil {
+					log.Fatal().Err(err).Msg("Failed to get user home directory")
+				}
+				dbPath = filepath.Join(homeDir, ".playbooks", "registry.db")
+			}
+
+			storage, err = playbook.NewStorage(dbPath)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to initialize storage")
+			}
+		},
+		PersistentPostRun: func(cmd *cobra.Command, args []string) {
+			if storage != nil {
+				storage.Close()
+			}
+		},
+	}
+
+	// Global flags
+	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level (debug, info, warn, error)")
+	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "", "Database path (default: ~/.playbooks/registry.db)")
+
+	// Add commands
+	rootCmd.AddCommand(registerCmd())
+	rootCmd.AddCommand(createCmd())
+	rootCmd.AddCommand(listCmd())
+	rootCmd.AddCommand(searchCmd())
+	rootCmd.AddCommand(showCmd())
+	rootCmd.AddCommand(addCmd())
+	rootCmd.AddCommand(removeCmd())
+	rootCmd.AddCommand(metaCmd())
+	rootCmd.AddCommand(deployCmd())
+	rootCmd.AddCommand(updateCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/googollee/go-socket.io v1.7.0
 	github.com/gorilla/mux v1.8.1
 	github.com/gorilla/websocket v1.5.3
+	github.com/gosimple/slug v1.15.0
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-plugin v1.4.10
 	github.com/hashicorp/terraform-exec v0.21.0
@@ -141,6 +142,7 @@ require (
 	github.com/google/s2a-go v0.1.8 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
+	github.com/gosimple/unidecode v1.0.1 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
 	github.com/huandu/go-clone v1.7.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,10 @@ github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWS
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/gosimple/slug v1.15.0 h1:wRZHsRrRcs6b0XnxMUBM6WK1U1Vg5B0R7VkIf1Xzobo=
+github.com/gosimple/slug v1.15.0/go.mod h1:UiRaFH+GEilHstLUmcBgWcI42viBN7mAb818JrYOeFQ=
+github.com/gosimple/unidecode v1.0.1 h1:hZzFTMMqSswvf0LBJZCZgThIZrpDHFXux9KeGmn6T/o=
+github.com/gosimple/unidecode v1.0.1/go.mod h1:CP0Cr1Y1kogOtx0bJblKzsVWrqYaqfNOnHzpgWw4Awc=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/pkg/playbook/commands.go
+++ b/pkg/playbook/commands.go
@@ -1,0 +1,1033 @@
+package playbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/rs/zerolog/log"
+)
+
+// RegisterCommand registers a playbook from file or URL
+type RegisterCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type RegisterSettings struct {
+	Title       string   `glazed.parameter:"title"`
+	Description string   `glazed.parameter:"description"`
+	Summary     string   `glazed.parameter:"summary"`
+	Metadata    []string `glazed.parameter:"metadata"`
+	Tags        []string `glazed.parameter:"tags"`
+	Filename    string   `glazed.parameter:"filename"`
+	Source      string   `glazed.parameter:"source"`
+}
+
+var _ cmds.WriterCommand = &RegisterCommand{}
+
+func NewRegisterCommand(storage *Storage) (*RegisterCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"register",
+		cmds.WithShort("Register a playbook from file or URL"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"source",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Path or URL to the playbook"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"title",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Title of the playbook"),
+				parameters.WithRequired(true),
+			),
+			parameters.NewParameterDefinition(
+				"description",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Description of the playbook"),
+			),
+			parameters.NewParameterDefinition(
+				"summary",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Summary of the playbook"),
+			),
+			parameters.NewParameterDefinition(
+				"metadata",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("Metadata in key=value format"),
+			),
+			parameters.NewParameterDefinition(
+				"tags",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("Tags for the playbook"),
+			),
+			parameters.NewParameterDefinition(
+				"filename",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Override filename"),
+			),
+		),
+	)
+
+	return &RegisterCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *RegisterCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &RegisterSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	// Read content from file or URL
+	var content string
+	var canonicalURL *string
+	var err error
+
+	if strings.HasPrefix(s.Source, "http://") || strings.HasPrefix(s.Source, "https://") {
+		content, err = fetchURL(s.Source)
+		canonicalURL = &s.Source
+	} else {
+		content, err = readFile(s.Source)
+		if s.Filename == "" {
+			s.Filename = filepath.Base(s.Source)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("failed to read content: %w", err)
+	}
+
+	// Create entity
+	entity := &Entity{
+		Type:         TypePlaybook,
+		Title:        s.Title,
+		Description:  s.Description,
+		Summary:      s.Summary,
+		CanonicalURL: canonicalURL,
+		Content:      &content,
+		Tags:         s.Tags,
+		LastFetched:  timePtr(time.Now()),
+	}
+
+	if s.Filename != "" {
+		entity.Filename = &s.Filename
+	}
+
+	// Parse metadata
+	if len(s.Metadata) > 0 {
+		entity.Metadata = make(map[string]string)
+		for _, meta := range s.Metadata {
+			parts := strings.SplitN(meta, "=", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid metadata format: %s (expected key=value)", meta)
+			}
+			entity.Metadata[parts[0]] = parts[1]
+		}
+	}
+
+	if err := c.storage.CreateEntity(entity); err != nil {
+		return fmt.Errorf("failed to create entity: %w", err)
+	}
+
+	fmt.Fprintf(w, "Registered playbook: %s (slug: %s)\n", entity.Title, entity.Slug)
+	return nil
+}
+
+// CreateCollectionCommand creates a new collection
+type CreateCollectionCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type CreateCollectionSettings struct {
+	Name        string   `glazed.parameter:"name"`
+	Title       string   `glazed.parameter:"title"`
+	Description string   `glazed.parameter:"description"`
+	Summary     string   `glazed.parameter:"summary"`
+	Metadata    []string `glazed.parameter:"metadata"`
+	Tags        []string `glazed.parameter:"tags"`
+}
+
+var _ cmds.WriterCommand = &CreateCollectionCommand{}
+
+func NewCreateCollectionCommand(storage *Storage) (*CreateCollectionCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"create-collection",
+		cmds.WithShort("Create a new collection"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"name",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Name of the collection"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"title",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Display title (defaults to name)"),
+			),
+			parameters.NewParameterDefinition(
+				"description",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Description of the collection"),
+			),
+			parameters.NewParameterDefinition(
+				"summary",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Summary of the collection"),
+			),
+			parameters.NewParameterDefinition(
+				"metadata",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("Metadata in key=value format"),
+			),
+			parameters.NewParameterDefinition(
+				"tags",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("Tags for the collection"),
+			),
+		),
+	)
+
+	return &CreateCollectionCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *CreateCollectionCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &CreateCollectionSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	title := s.Title
+	if title == "" {
+		title = s.Name
+	}
+
+	entity := &Entity{
+		Type:        TypeCollection,
+		Title:       title,
+		Description: s.Description,
+		Summary:     s.Summary,
+		Tags:        s.Tags,
+	}
+
+	// Parse metadata
+	if len(s.Metadata) > 0 {
+		entity.Metadata = make(map[string]string)
+		for _, meta := range s.Metadata {
+			parts := strings.SplitN(meta, "=", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("invalid metadata format: %s (expected key=value)", meta)
+			}
+			entity.Metadata[parts[0]] = parts[1]
+		}
+	}
+
+	if err := c.storage.CreateEntity(entity); err != nil {
+		return fmt.Errorf("failed to create collection: %w", err)
+	}
+
+	fmt.Fprintf(w, "Created collection: %s (slug: %s)\n", entity.Title, entity.Slug)
+	return nil
+}
+
+// ListCommand lists entities with optional filters
+type ListCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type ListSettings struct {
+	EntityType string   `glazed.parameter:"type"`
+	Tags       []string `glazed.parameter:"tags"`
+}
+
+var _ cmds.GlazeCommand = &ListCommand{}
+
+func NewListCommand(storage *Storage) (*ListCommand, error) {
+	glazedLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdDesc := cmds.NewCommandDescription(
+		"list",
+		cmds.WithShort("List entities with optional filters"),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"type",
+				parameters.ParameterTypeChoice,
+				parameters.WithHelp("Filter by type"),
+				parameters.WithChoices("playbook", "collection"),
+			),
+			parameters.NewParameterDefinition(
+				"tags",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("Filter by tags"),
+			),
+		),
+		cmds.WithLayersList(glazedLayer),
+	)
+
+	return &ListCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *ListCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+	s := &ListSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	var typeFilter *EntityType
+	if s.EntityType != "" {
+		switch s.EntityType {
+		case "playbook":
+			t := TypePlaybook
+			typeFilter = &t
+		case "collection":
+			t := TypeCollection
+			typeFilter = &t
+		default:
+			return fmt.Errorf("invalid type: %s (must be 'playbook' or 'collection')", s.EntityType)
+		}
+	}
+
+	entities, err := c.storage.ListEntities(typeFilter, s.Tags)
+	if err != nil {
+		return fmt.Errorf("failed to list entities: %w", err)
+	}
+
+	for _, entity := range entities {
+		row := types.NewRow(
+			types.MRP("slug", entity.Slug),
+			types.MRP("type", string(entity.Type)),
+			types.MRP("title", entity.Title),
+			types.MRP("summary", entity.Summary),
+			types.MRP("description", entity.Description),
+			types.MRP("tags", strings.Join(entity.Tags, ", ")),
+			types.MRP("created_at", entity.CreatedAt.Format(time.RFC3339)),
+		)
+
+		if entity.CanonicalURL != nil {
+			row.Set("canonical_url", *entity.CanonicalURL)
+		}
+		if entity.LastFetched != nil {
+			row.Set("last_fetched", entity.LastFetched.Format(time.RFC3339))
+		}
+
+		if err := gp.AddRow(ctx, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// SearchCommand searches entities
+type SearchCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type SearchSettings struct {
+	Query      string `glazed.parameter:"query"`
+	EntityType string `glazed.parameter:"type"`
+}
+
+var _ cmds.GlazeCommand = &SearchCommand{}
+
+func NewSearchCommand(storage *Storage) (*SearchCommand, error) {
+	glazedLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdDesc := cmds.NewCommandDescription(
+		"search",
+		cmds.WithShort("Search entities by query string"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"query",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Search query"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"type",
+				parameters.ParameterTypeChoice,
+				parameters.WithHelp("Filter by type"),
+				parameters.WithChoices("playbook", "collection"),
+			),
+		),
+		cmds.WithLayersList(glazedLayer),
+	)
+
+	return &SearchCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *SearchCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+	s := &SearchSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	var typeFilter *EntityType
+	if s.EntityType != "" {
+		switch s.EntityType {
+		case "playbook":
+			t := TypePlaybook
+			typeFilter = &t
+		case "collection":
+			t := TypeCollection
+			typeFilter = &t
+		default:
+			return fmt.Errorf("invalid type: %s (must be 'playbook' or 'collection')", s.EntityType)
+		}
+	}
+
+	entities, err := c.storage.SearchEntities(s.Query, typeFilter)
+	if err != nil {
+		return fmt.Errorf("failed to search entities: %w", err)
+	}
+
+	for _, entity := range entities {
+		row := types.NewRow(
+			types.MRP("slug", entity.Slug),
+			types.MRP("type", string(entity.Type)),
+			types.MRP("title", entity.Title),
+			types.MRP("summary", entity.Summary),
+			types.MRP("description", entity.Description),
+			types.MRP("tags", strings.Join(entity.Tags, ", ")),
+			types.MRP("created_at", entity.CreatedAt.Format(time.RFC3339)),
+		)
+
+		if entity.CanonicalURL != nil {
+			row.Set("canonical_url", *entity.CanonicalURL)
+		}
+		if entity.LastFetched != nil {
+			row.Set("last_fetched", entity.LastFetched.Format(time.RFC3339))
+		}
+
+		if err := gp.AddRow(ctx, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ShowCommand shows detailed information about an entity
+type ShowCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type ShowSettings struct {
+	Slug string `glazed.parameter:"slug"`
+}
+
+var _ cmds.WriterCommand = &ShowCommand{}
+
+func NewShowCommand(storage *Storage) (*ShowCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"show",
+		cmds.WithShort("Show detailed information about an entity"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Entity slug"),
+				parameters.WithRequired(true),
+			),
+		),
+	)
+
+	return &ShowCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *ShowCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &ShowSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	entity, err := c.storage.GetEntityBySlug(s.Slug)
+	if err != nil {
+		return fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	fmt.Fprintf(w, "Slug: %s\n", entity.Slug)
+	fmt.Fprintf(w, "Type: %s\n", entity.Type)
+	fmt.Fprintf(w, "Title: %s\n", entity.Title)
+	if entity.Description != "" {
+		fmt.Fprintf(w, "Description: %s\n", entity.Description)
+	}
+	if entity.Summary != "" {
+		fmt.Fprintf(w, "Summary: %s\n", entity.Summary)
+	}
+	if entity.CanonicalURL != nil {
+		fmt.Fprintf(w, "URL: %s\n", *entity.CanonicalURL)
+	}
+	if entity.Filename != nil {
+		fmt.Fprintf(w, "Filename: %s\n", *entity.Filename)
+	}
+	if len(entity.Tags) > 0 {
+		fmt.Fprintf(w, "Tags: %s\n", strings.Join(entity.Tags, ", "))
+	}
+	if entity.LastFetched != nil {
+		fmt.Fprintf(w, "Last Fetched: %s\n", entity.LastFetched.Format(time.RFC3339))
+	}
+	fmt.Fprintf(w, "Created: %s\n", entity.CreatedAt.Format(time.RFC3339))
+
+	// Show metadata
+	if len(entity.Metadata) > 0 {
+		fmt.Fprintf(w, "\nMetadata:\n")
+		for key, value := range entity.Metadata {
+			fmt.Fprintf(w, "  %s: %s\n", key, value)
+		}
+	}
+
+	// Show collection members if it's a collection
+	if entity.Type == TypeCollection {
+		members, err := c.storage.GetCollectionMembers(entity.ID)
+		if err != nil {
+			log.Warn().Err(err).Msg("Failed to get collection members")
+		} else if len(members) > 0 {
+			fmt.Fprintf(w, "\nMembers:\n")
+			for _, member := range members {
+				memberEntity, err := c.storage.GetEntityByID(member.MemberID)
+				if err != nil {
+					fmt.Fprintf(w, "  ID %d (error loading details)\n", member.MemberID)
+				} else {
+					fmt.Fprintf(w, "  %s (%s) - %s\n", memberEntity.Slug, memberEntity.Type, memberEntity.Title)
+					if member.RelativePath != nil {
+						fmt.Fprintf(w, "    Path: %s\n", *member.RelativePath)
+					}
+				}
+			}
+		}
+	}
+
+	// Show content if it's a playbook
+	if entity.Type == TypePlaybook && entity.Content != nil {
+		fmt.Fprintf(w, "\nContent:\n")
+		fmt.Fprintf(w, "%s\n", *entity.Content)
+	}
+
+	return nil
+}
+
+// DeployCommand deploys entities to directories
+type DeployCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type DeploySettings struct {
+	Slug             string `glazed.parameter:"slug"`
+	TargetDirectory  string `glazed.parameter:"target_directory"`
+	FilenameOverride string `glazed.parameter:"filename"`
+}
+
+var _ cmds.WriterCommand = &DeployCommand{}
+
+func NewDeployCommand(storage *Storage) (*DeployCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"deploy",
+		cmds.WithShort("Deploy an entity to a target directory"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Entity slug"),
+				parameters.WithRequired(true),
+			),
+			parameters.NewParameterDefinition(
+				"target_directory",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Target directory"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"filename",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Override filename for playbook deployment"),
+			),
+		),
+	)
+
+	return &DeployCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *DeployCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &DeploySettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	entity, err := c.storage.GetEntityBySlug(s.Slug)
+	if err != nil {
+		return fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	if err := os.MkdirAll(s.TargetDirectory, 0755); err != nil {
+		return fmt.Errorf("failed to create target directory: %w", err)
+	}
+
+	if entity.Type == TypePlaybook {
+		// Deploy single playbook
+		filename := s.FilenameOverride
+		if filename == "" && entity.Filename != nil {
+			filename = *entity.Filename
+		}
+		if filename == "" {
+			filename = entity.Slug + ".md"
+		}
+
+		filePath := filepath.Join(s.TargetDirectory, filename)
+		if err := os.WriteFile(filePath, []byte(*entity.Content), 0644); err != nil {
+			return fmt.Errorf("failed to write file: %w", err)
+		}
+
+		fmt.Fprintf(w, "Deployed playbook %s to %s\n", entity.Title, filePath)
+	} else {
+		// Deploy collection - create subdirectory with collection slug
+		collectionDir := filepath.Join(s.TargetDirectory, entity.Slug)
+		if err := os.MkdirAll(collectionDir, 0755); err != nil {
+			return fmt.Errorf("failed to create collection directory: %w", err)
+		}
+
+		members, err := c.storage.GetCollectionMembers(entity.ID)
+		if err != nil {
+			return fmt.Errorf("failed to get collection members: %w", err)
+		}
+
+		for _, member := range members {
+			memberEntity, err := c.storage.GetEntityByID(member.MemberID)
+			if err != nil {
+				log.Warn().Err(err).Int64("member_id", member.MemberID).Msg("Failed to load member")
+				continue
+			}
+
+			if memberEntity.Type == TypePlaybook && memberEntity.Content != nil {
+				filename := ""
+				if member.RelativePath != nil {
+					filename = *member.RelativePath
+				} else if memberEntity.Filename != nil {
+					filename = *memberEntity.Filename
+				} else {
+					filename = memberEntity.Slug + ".md"
+				}
+
+				filePath := filepath.Join(collectionDir, filename)
+				
+				// Create parent directory if needed
+				if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+					log.Warn().Err(err).Str("path", filepath.Dir(filePath)).Msg("Failed to create directory")
+					continue
+				}
+
+				if err := os.WriteFile(filePath, []byte(*memberEntity.Content), 0644); err != nil {
+					log.Warn().Err(err).Str("path", filePath).Msg("Failed to write file")
+					continue
+				}
+
+				fmt.Fprintf(w, "Deployed %s to %s\n", memberEntity.Title, filePath)
+			}
+		}
+
+		fmt.Fprintf(w, "Deployed collection %s to %s\n", entity.Title, collectionDir)
+	}
+
+	// Record deployment
+	if err := c.storage.RecordDeployment(entity.ID, s.TargetDirectory); err != nil {
+		log.Warn().Err(err).Msg("Failed to record deployment")
+	}
+
+	return nil
+}
+
+// Helper functions
+
+func fetchURL(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
+func readFile(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}
+
+// AddToCollectionCommand adds entities to collections
+type AddToCollectionCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type AddToCollectionSettings struct {
+	CollectionSlug string `glazed.parameter:"collection_slug"`
+	MemberSlug     string `glazed.parameter:"member_slug"`
+	RelativePath   string `glazed.parameter:"path"`
+}
+
+var _ cmds.WriterCommand = &AddToCollectionCommand{}
+
+func NewAddToCollectionCommand(storage *Storage) (*AddToCollectionCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"add",
+		cmds.WithShort("Add a member to a collection"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"collection_slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Collection slug"),
+				parameters.WithRequired(true),
+			),
+			parameters.NewParameterDefinition(
+				"member_slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Member slug"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"path",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Relative path within collection"),
+			),
+		),
+	)
+
+	return &AddToCollectionCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *AddToCollectionCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &AddToCollectionSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	collection, err := c.storage.GetEntityBySlug(s.CollectionSlug)
+	if err != nil {
+		return fmt.Errorf("failed to get collection: %w", err)
+	}
+	if collection.Type != TypeCollection {
+		return fmt.Errorf("%s is not a collection", s.CollectionSlug)
+	}
+
+	member, err := c.storage.GetEntityBySlug(s.MemberSlug)
+	if err != nil {
+		return fmt.Errorf("failed to get member: %w", err)
+	}
+
+	var relPath *string
+	if s.RelativePath != "" {
+		relPath = &s.RelativePath
+	}
+
+	if err := c.storage.AddToCollection(collection.ID, member.ID, relPath); err != nil {
+		return fmt.Errorf("failed to add to collection: %w", err)
+	}
+
+	fmt.Fprintf(w, "Added %s to collection %s\n", member.Title, collection.Title)
+	return nil
+}
+
+// RemoveCommand removes entities from collections or deletes entities
+type RemoveCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type RemoveSettings struct {
+	CollectionSlug string `glazed.parameter:"collection_slug"`
+	MemberSlug     string `glazed.parameter:"member_slug"`
+	EntitySlug     string `glazed.parameter:"entity_slug"`
+}
+
+var _ cmds.WriterCommand = &RemoveCommand{}
+
+func NewRemoveCommand(storage *Storage) (*RemoveCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"remove",
+		cmds.WithShort("Remove a member from a collection or delete an entity"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"collection_slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Collection slug (for removing from collection)"),
+			),
+			parameters.NewParameterDefinition(
+				"member_slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Member slug (for removing from collection) or entity slug (for deletion)"),
+			),
+		),
+	)
+
+	return &RemoveCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *RemoveCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &RemoveSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	if s.MemberSlug == "" {
+		return fmt.Errorf("missing required argument: member_slug or entity_slug")
+	}
+
+	if s.CollectionSlug == "" {
+		// Delete entity
+		entity, err := c.storage.GetEntityBySlug(s.MemberSlug)
+		if err != nil {
+			return fmt.Errorf("failed to get entity: %w", err)
+		}
+
+		if err := c.storage.DeleteEntity(entity.ID); err != nil {
+			return fmt.Errorf("failed to delete entity: %w", err)
+		}
+
+		fmt.Fprintf(w, "Deleted %s (%s)\n", entity.Title, entity.Type)
+		return nil
+	}
+
+	// Remove from collection
+	collection, err := c.storage.GetEntityBySlug(s.CollectionSlug)
+	if err != nil {
+		return fmt.Errorf("failed to get collection: %w", err)
+	}
+	if collection.Type != TypeCollection {
+		return fmt.Errorf("%s is not a collection", s.CollectionSlug)
+	}
+
+	member, err := c.storage.GetEntityBySlug(s.MemberSlug)
+	if err != nil {
+		return fmt.Errorf("failed to get member: %w", err)
+	}
+
+	if err := c.storage.RemoveFromCollection(collection.ID, member.ID); err != nil {
+		return fmt.Errorf("failed to remove from collection: %w", err)
+	}
+
+	fmt.Fprintf(w, "Removed %s from collection %s\n", member.Title, collection.Title)
+	return nil
+}
+
+// SetMetadataCommand sets metadata for an entity
+type SetMetadataCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type SetMetadataSettings struct {
+	Slug  string `glazed.parameter:"slug"`
+	Key   string `glazed.parameter:"key"`
+	Value string `glazed.parameter:"value"`
+}
+
+var _ cmds.WriterCommand = &SetMetadataCommand{}
+
+func NewSetMetadataCommand(storage *Storage) (*SetMetadataCommand, error) {
+	cmdDesc := cmds.NewCommandDescription(
+		"set-meta",
+		cmds.WithShort("Set metadata for an entity"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Entity slug"),
+				parameters.WithRequired(true),
+			),
+			parameters.NewParameterDefinition(
+				"key",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Metadata key"),
+				parameters.WithRequired(true),
+			),
+			parameters.NewParameterDefinition(
+				"value",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Metadata value"),
+				parameters.WithRequired(true),
+			),
+		),
+	)
+
+	return &SetMetadataCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *SetMetadataCommand) RunIntoWriter(ctx context.Context, parsedLayers *layers.ParsedLayers, w io.Writer) error {
+	s := &SetMetadataSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	entity, err := c.storage.GetEntityBySlug(s.Slug)
+	if err != nil {
+		return fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	if err := c.storage.SetMetadata(entity.ID, s.Key, s.Value); err != nil {
+		return fmt.Errorf("failed to set metadata: %w", err)
+	}
+
+	fmt.Fprintf(w, "Set metadata %s=%s for %s\n", s.Key, s.Value, entity.Title)
+	return nil
+}
+
+// GetMetadataCommand gets metadata for an entity
+type GetMetadataCommand struct {
+	*cmds.CommandDescription
+	storage *Storage
+}
+
+type GetMetadataSettings struct {
+	Slug string `glazed.parameter:"slug"`
+	Key  string `glazed.parameter:"key"`
+}
+
+var _ cmds.GlazeCommand = &GetMetadataCommand{}
+
+func NewGetMetadataCommand(storage *Storage) (*GetMetadataCommand, error) {
+	glazedLayer, err := settings.NewGlazedParameterLayers()
+	if err != nil {
+		return nil, err
+	}
+
+	cmdDesc := cmds.NewCommandDescription(
+		"get-meta",
+		cmds.WithShort("Get metadata for an entity"),
+		cmds.WithArguments(
+			parameters.NewParameterDefinition(
+				"slug",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Entity slug"),
+				parameters.WithRequired(true),
+			),
+		),
+		cmds.WithFlags(
+			parameters.NewParameterDefinition(
+				"key",
+				parameters.ParameterTypeString,
+				parameters.WithHelp("Specific metadata key (optional)"),
+			),
+		),
+		cmds.WithLayersList(glazedLayer),
+	)
+
+	return &GetMetadataCommand{
+		CommandDescription: cmdDesc,
+		storage:           storage,
+	}, nil
+}
+
+func (c *GetMetadataCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+	s := &GetMetadataSettings{}
+	if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+		return err
+	}
+
+	entity, err := c.storage.GetEntityBySlug(s.Slug)
+	if err != nil {
+		return fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	metadata, err := c.storage.GetMetadata(entity.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get metadata: %w", err)
+	}
+
+	if s.Key != "" {
+		// Get specific key
+		if value, exists := metadata[s.Key]; exists {
+			row := types.NewRow(
+				types.MRP("key", s.Key),
+				types.MRP("value", value),
+			)
+			return gp.AddRow(ctx, row)
+		} else {
+			return fmt.Errorf("metadata key %s not found", s.Key)
+		}
+	} else {
+		// Get all metadata
+		for key, value := range metadata {
+			row := types.NewRow(
+				types.MRP("key", key),
+				types.MRP("value", value),
+			)
+			if err := gp.AddRow(ctx, row); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/playbook/models.go
+++ b/pkg/playbook/models.go
@@ -1,0 +1,105 @@
+package playbook
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gosimple/slug"
+)
+
+type EntityType string
+
+const (
+	TypePlaybook   EntityType = "playbook"
+	TypeCollection EntityType = "collection"
+)
+
+// Entity represents both playbooks and collections
+type Entity struct {
+	ID           int64     `json:"id" db:"id"`
+	Slug         string    `json:"slug" db:"slug"`
+	Type         EntityType `json:"type" db:"type"`
+	Title        string    `json:"title" db:"title"`
+	Description  string    `json:"description" db:"description"`
+	Summary      string    `json:"summary" db:"summary"`
+	CanonicalURL *string   `json:"canonical_url,omitempty" db:"canonical_url"`
+	Content      *string   `json:"content,omitempty" db:"content"`
+	ContentHash  *string   `json:"content_hash,omitempty" db:"content_hash"`
+	Filename     *string   `json:"filename,omitempty" db:"filename"`
+	Tags         []string  `json:"tags" db:"tags"`
+	LastFetched  *time.Time `json:"last_fetched,omitempty" db:"last_fetched"`
+	CreatedAt    time.Time `json:"created_at" db:"created_at"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// EntityMetadata represents key-value metadata for entities
+type EntityMetadata struct {
+	EntityID int64  `json:"entity_id" db:"entity_id"`
+	Key      string `json:"key" db:"key"`
+	Value    string `json:"value" db:"value"`
+}
+
+// CollectionMember represents membership in a collection
+type CollectionMember struct {
+	CollectionID int64   `json:"collection_id" db:"collection_id"`
+	MemberID     int64   `json:"member_id" db:"member_id"`
+	RelativePath *string `json:"relative_path,omitempty" db:"relative_path"`
+}
+
+// Deployment represents a deployment of an entity to a directory
+type Deployment struct {
+	ID              int64     `json:"id" db:"id"`
+	EntityID        int64     `json:"entity_id" db:"entity_id"`
+	TargetDirectory string    `json:"target_directory" db:"target_directory"`
+	DeployedAt      time.Time `json:"deployed_at" db:"deployed_at"`
+}
+
+// GenerateSlug creates a URL-friendly slug from the title
+func GenerateSlug(title string) string {
+	return slug.Make(title)
+}
+
+// MarshalTags converts tags slice to JSON string for database storage
+func (e *Entity) MarshalTags() (string, error) {
+	if len(e.Tags) == 0 {
+		return "[]", nil
+	}
+	bytes, err := json.Marshal(e.Tags)
+	return string(bytes), err
+}
+
+// UnmarshalTags converts JSON string from database to tags slice
+func (e *Entity) UnmarshalTags(tagsJSON string) error {
+	if tagsJSON == "" {
+		e.Tags = []string{}
+		return nil
+	}
+	return json.Unmarshal([]byte(tagsJSON), &e.Tags)
+}
+
+// HasTag checks if entity has a specific tag
+func (e *Entity) HasTag(tag string) bool {
+	for _, t := range e.Tags {
+		if t == tag {
+			return true
+		}
+	}
+	return false
+}
+
+// AddTag adds a tag if it doesn't already exist
+func (e *Entity) AddTag(tag string) {
+	if !e.HasTag(tag) {
+		e.Tags = append(e.Tags, tag)
+	}
+}
+
+// RemoveTag removes a tag if it exists
+func (e *Entity) RemoveTag(tag string) {
+	for i, t := range e.Tags {
+		if t == tag {
+			e.Tags = append(e.Tags[:i], e.Tags[i+1:]...)
+			break
+		}
+	}
+}

--- a/pkg/playbook/models.go
+++ b/pkg/playbook/models.go
@@ -24,6 +24,7 @@ type Entity struct {
 	Summary      string    `json:"summary" db:"summary"`
 	CanonicalURL *string   `json:"canonical_url,omitempty" db:"canonical_url"`
 	Content      *string   `json:"content,omitempty" db:"content"`
+	Command      *string   `json:"command,omitempty" db:"command"`
 	ContentHash  *string   `json:"content_hash,omitempty" db:"content_hash"`
 	Filename     *string   `json:"filename,omitempty" db:"filename"`
 	Tags         []string  `json:"tags" db:"tags"`
@@ -102,4 +103,20 @@ func (e *Entity) RemoveTag(tag string) {
 			break
 		}
 	}
+}
+
+// IsCommand returns true if this entity represents a shell command
+func (e *Entity) IsCommand() bool {
+	return e.Command != nil && *e.Command != ""
+}
+
+// GetContentOrCommand returns the content for file-based playbooks or command for shell playbooks
+func (e *Entity) GetContentOrCommand() string {
+	if e.IsCommand() {
+		return *e.Command
+	}
+	if e.Content != nil {
+		return *e.Content
+	}
+	return ""
 }

--- a/pkg/playbook/storage.go
+++ b/pkg/playbook/storage.go
@@ -1,0 +1,445 @@
+package playbook
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Storage handles database operations for playbooks
+type Storage struct {
+	db *sql.DB
+}
+
+// NewStorage creates a new storage instance and initializes the database
+func NewStorage(dbPath string) (*Storage, error) {
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(dbPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create directory %s: %w", dir, err)
+	}
+
+	db, err := sql.Open("sqlite3", dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %w", err)
+	}
+
+	storage := &Storage{db: db}
+	if err := storage.initDB(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("failed to initialize database: %w", err)
+	}
+
+	return storage, nil
+}
+
+// Close closes the database connection
+func (s *Storage) Close() error {
+	return s.db.Close()
+}
+
+// initDB creates the database schema
+func (s *Storage) initDB() error {
+	schema := `
+	-- Unified entities table (both playbooks and collections)
+	CREATE TABLE IF NOT EXISTS entities (
+		id INTEGER PRIMARY KEY,
+		slug TEXT UNIQUE NOT NULL,
+		type TEXT NOT NULL CHECK (type IN ('playbook', 'collection')),
+		title TEXT NOT NULL,
+		description TEXT,
+		summary TEXT,
+		canonical_url TEXT,
+		content TEXT,
+		content_hash TEXT,
+		filename TEXT,
+		tags TEXT DEFAULT '[]',
+		last_fetched DATETIME,
+		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	CREATE TABLE IF NOT EXISTS entity_metadata (
+		entity_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+		key TEXT NOT NULL,
+		value TEXT NOT NULL,
+		PRIMARY KEY (entity_id, key)
+	);
+
+	-- Collection membership (what playbooks/collections are in a collection)
+	CREATE TABLE IF NOT EXISTS collection_members (
+		collection_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+		member_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+		relative_path TEXT,
+		PRIMARY KEY (collection_id, member_id)
+	);
+
+	CREATE TABLE IF NOT EXISTS deployments (
+		id INTEGER PRIMARY KEY,
+		entity_id INTEGER REFERENCES entities(id),
+		target_directory TEXT,
+		deployed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+	);
+
+	-- Create indexes for better performance
+	CREATE INDEX IF NOT EXISTS idx_entities_slug ON entities(slug);
+	CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(type);
+	CREATE INDEX IF NOT EXISTS idx_entities_created_at ON entities(created_at);
+	CREATE INDEX IF NOT EXISTS idx_collection_members_collection_id ON collection_members(collection_id);
+	CREATE INDEX IF NOT EXISTS idx_collection_members_member_id ON collection_members(member_id);
+	`
+
+	_, err := s.db.Exec(schema)
+	return err
+}
+
+// CreateEntity creates a new entity (playbook or collection)
+func (s *Storage) CreateEntity(entity *Entity) error {
+	// Generate slug from title
+	entity.Slug = GenerateSlug(entity.Title)
+	
+	// Handle slug conflicts by appending numbers
+	originalSlug := entity.Slug
+	counter := 1
+	for {
+		if !s.slugExists(entity.Slug) {
+			break
+		}
+		entity.Slug = fmt.Sprintf("%s-%d", originalSlug, counter)
+		counter++
+	}
+
+	// Calculate content hash for playbooks
+	if entity.Type == TypePlaybook && entity.Content != nil {
+		hash := sha256.Sum256([]byte(*entity.Content))
+		hashStr := hex.EncodeToString(hash[:])
+		entity.ContentHash = &hashStr
+	}
+
+	// Marshal tags
+	tagsJSON, err := entity.MarshalTags()
+	if err != nil {
+		return fmt.Errorf("failed to marshal tags: %w", err)
+	}
+
+	// Insert entity
+	result, err := s.db.Exec(`
+		INSERT INTO entities (slug, type, title, description, summary, canonical_url, content, content_hash, filename, tags, last_fetched)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, entity.Slug, entity.Type, entity.Title, entity.Description, entity.Summary,
+		entity.CanonicalURL, entity.Content, entity.ContentHash, entity.Filename, tagsJSON, entity.LastFetched)
+
+	if err != nil {
+		return fmt.Errorf("failed to insert entity: %w", err)
+	}
+
+	entityID, err := result.LastInsertId()
+	if err != nil {
+		return fmt.Errorf("failed to get entity ID: %w", err)
+	}
+	entity.ID = entityID
+
+	// Insert metadata if provided
+	if entity.Metadata != nil {
+		for key, value := range entity.Metadata {
+			if err := s.SetMetadata(entity.ID, key, value); err != nil {
+				return fmt.Errorf("failed to set metadata %s: %w", key, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetEntityBySlug retrieves an entity by its slug
+func (s *Storage) GetEntityBySlug(slug string) (*Entity, error) {
+	entity := &Entity{}
+	var tagsJSON string
+
+	err := s.db.QueryRow(`
+		SELECT id, slug, type, title, description, summary, canonical_url, content, content_hash, filename, tags, last_fetched, created_at
+		FROM entities WHERE slug = ?
+	`, slug).Scan(&entity.ID, &entity.Slug, &entity.Type, &entity.Title, &entity.Description, &entity.Summary,
+		&entity.CanonicalURL, &entity.Content, &entity.ContentHash, &entity.Filename, &tagsJSON, &entity.LastFetched, &entity.CreatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("entity with slug %s not found", slug)
+		}
+		return nil, fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	// Unmarshal tags
+	if err := entity.UnmarshalTags(tagsJSON); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tags: %w", err)
+	}
+
+	// Load metadata
+	metadata, err := s.GetMetadata(entity.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+	entity.Metadata = metadata
+
+	return entity, nil
+}
+
+// GetEntityByID retrieves an entity by its ID
+func (s *Storage) GetEntityByID(id int64) (*Entity, error) {
+	entity := &Entity{}
+	var tagsJSON string
+
+	err := s.db.QueryRow(`
+		SELECT id, slug, type, title, description, summary, canonical_url, content, content_hash, filename, tags, last_fetched, created_at
+		FROM entities WHERE id = ?
+	`, id).Scan(&entity.ID, &entity.Slug, &entity.Type, &entity.Title, &entity.Description, &entity.Summary,
+		&entity.CanonicalURL, &entity.Content, &entity.ContentHash, &entity.Filename, &tagsJSON, &entity.LastFetched, &entity.CreatedAt)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("entity with ID %d not found", id)
+		}
+		return nil, fmt.Errorf("failed to get entity: %w", err)
+	}
+
+	// Unmarshal tags
+	if err := entity.UnmarshalTags(tagsJSON); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tags: %w", err)
+	}
+
+	// Load metadata
+	metadata, err := s.GetMetadata(entity.ID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load metadata: %w", err)
+	}
+	entity.Metadata = metadata
+
+	return entity, nil
+}
+
+// ListEntities lists entities with optional filters
+func (s *Storage) ListEntities(entityType *EntityType, tags []string) ([]*Entity, error) {
+	query := `
+		SELECT id, slug, type, title, description, summary, canonical_url, content, content_hash, filename, tags, last_fetched, created_at
+		FROM entities WHERE 1=1
+	`
+	args := []interface{}{}
+
+	if entityType != nil {
+		query += " AND type = ?"
+		args = append(args, *entityType)
+	}
+
+	if len(tags) > 0 {
+		for _, tag := range tags {
+			query += " AND tags LIKE ?"
+			args = append(args, "%\""+tag+"\"%")
+		}
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query entities: %w", err)
+	}
+	defer rows.Close()
+
+	var entities []*Entity
+	for rows.Next() {
+		entity := &Entity{}
+		var tagsJSON string
+
+		err := rows.Scan(&entity.ID, &entity.Slug, &entity.Type, &entity.Title, &entity.Description, &entity.Summary,
+			&entity.CanonicalURL, &entity.Content, &entity.ContentHash, &entity.Filename, &tagsJSON, &entity.LastFetched, &entity.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan entity: %w", err)
+		}
+
+		// Unmarshal tags
+		if err := entity.UnmarshalTags(tagsJSON); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tags: %w", err)
+		}
+
+		entities = append(entities, entity)
+	}
+
+	return entities, nil
+}
+
+// SearchEntities searches entities by query string
+func (s *Storage) SearchEntities(query string, entityType *EntityType) ([]*Entity, error) {
+	searchQuery := `
+		SELECT id, slug, type, title, description, summary, canonical_url, content, content_hash, filename, tags, last_fetched, created_at
+		FROM entities 
+		WHERE (title LIKE ? OR description LIKE ? OR summary LIKE ? OR content LIKE ?)
+	`
+	args := []interface{}{
+		"%" + query + "%",
+		"%" + query + "%",
+		"%" + query + "%",
+		"%" + query + "%",
+	}
+
+	if entityType != nil {
+		searchQuery += " AND type = ?"
+		args = append(args, *entityType)
+	}
+
+	searchQuery += " ORDER BY created_at DESC"
+
+	rows, err := s.db.Query(searchQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search entities: %w", err)
+	}
+	defer rows.Close()
+
+	var entities []*Entity
+	for rows.Next() {
+		entity := &Entity{}
+		var tagsJSON string
+
+		err := rows.Scan(&entity.ID, &entity.Slug, &entity.Type, &entity.Title, &entity.Description, &entity.Summary,
+			&entity.CanonicalURL, &entity.Content, &entity.ContentHash, &entity.Filename, &tagsJSON, &entity.LastFetched, &entity.CreatedAt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan entity: %w", err)
+		}
+
+		// Unmarshal tags
+		if err := entity.UnmarshalTags(tagsJSON); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal tags: %w", err)
+		}
+
+		entities = append(entities, entity)
+	}
+
+	return entities, nil
+}
+
+// SetMetadata sets metadata for an entity
+func (s *Storage) SetMetadata(entityID int64, key, value string) error {
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO entity_metadata (entity_id, key, value)
+		VALUES (?, ?, ?)
+	`, entityID, key, value)
+	return err
+}
+
+// GetMetadata gets all metadata for an entity
+func (s *Storage) GetMetadata(entityID int64) (map[string]string, error) {
+	rows, err := s.db.Query(`
+		SELECT key, value FROM entity_metadata WHERE entity_id = ?
+	`, entityID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	metadata := make(map[string]string)
+	for rows.Next() {
+		var key, value string
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, err
+		}
+		metadata[key] = value
+	}
+
+	return metadata, nil
+}
+
+// DeleteMetadata removes metadata for an entity
+func (s *Storage) DeleteMetadata(entityID int64, key string) error {
+	_, err := s.db.Exec(`
+		DELETE FROM entity_metadata WHERE entity_id = ? AND key = ?
+	`, entityID, key)
+	return err
+}
+
+// AddToCollection adds an entity to a collection
+func (s *Storage) AddToCollection(collectionID, memberID int64, relativePath *string) error {
+	_, err := s.db.Exec(`
+		INSERT OR REPLACE INTO collection_members (collection_id, member_id, relative_path)
+		VALUES (?, ?, ?)
+	`, collectionID, memberID, relativePath)
+	return err
+}
+
+// RemoveFromCollection removes an entity from a collection
+func (s *Storage) RemoveFromCollection(collectionID, memberID int64) error {
+	_, err := s.db.Exec(`
+		DELETE FROM collection_members WHERE collection_id = ? AND member_id = ?
+	`, collectionID, memberID)
+	return err
+}
+
+// GetCollectionMembers gets all members of a collection
+func (s *Storage) GetCollectionMembers(collectionID int64) ([]*CollectionMember, error) {
+	rows, err := s.db.Query(`
+		SELECT collection_id, member_id, relative_path
+		FROM collection_members WHERE collection_id = ?
+	`, collectionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var members []*CollectionMember
+	for rows.Next() {
+		member := &CollectionMember{}
+		if err := rows.Scan(&member.CollectionID, &member.MemberID, &member.RelativePath); err != nil {
+			return nil, err
+		}
+		members = append(members, member)
+	}
+
+	return members, nil
+}
+
+// DeleteEntity deletes an entity and all related data
+func (s *Storage) DeleteEntity(id int64) error {
+	_, err := s.db.Exec(`DELETE FROM entities WHERE id = ?`, id)
+	return err
+}
+
+// RecordDeployment records a deployment
+func (s *Storage) RecordDeployment(entityID int64, targetDirectory string) error {
+	_, err := s.db.Exec(`
+		INSERT INTO deployments (entity_id, target_directory)
+		VALUES (?, ?)
+	`, entityID, targetDirectory)
+	return err
+}
+
+// GetDeployments gets deployments for an entity
+func (s *Storage) GetDeployments(entityID int64) ([]*Deployment, error) {
+	rows, err := s.db.Query(`
+		SELECT id, entity_id, target_directory, deployed_at
+		FROM deployments WHERE entity_id = ? ORDER BY deployed_at DESC
+	`, entityID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var deployments []*Deployment
+	for rows.Next() {
+		deployment := &Deployment{}
+		if err := rows.Scan(&deployment.ID, &deployment.EntityID, &deployment.TargetDirectory, &deployment.DeployedAt); err != nil {
+			return nil, err
+		}
+		deployments = append(deployments, deployment)
+	}
+
+	return deployments, nil
+}
+
+// slugExists checks if a slug already exists
+func (s *Storage) slugExists(slug string) bool {
+	var count int
+	s.db.QueryRow("SELECT COUNT(*) FROM entities WHERE slug = ?", slug).Scan(&count)
+	return count > 0
+}

--- a/test-playbook.md
+++ b/test-playbook.md
@@ -1,0 +1,16 @@
+# Python Coding Standards
+
+## Overview
+This document outlines the coding standards for Python development.
+
+## Rules
+1. Use snake_case for variable names
+2. Use PascalCase for class names
+3. Maximum line length is 88 characters
+4. Use type hints for all function parameters
+
+## Examples
+```python
+def calculate_total(items: List[Item]) -> float:
+    return sum(item.price for item in items)
+```

--- a/ttmp/2025-06-01/playbook-manager/01-playbook-manager-design.md
+++ b/ttmp/2025-06-01/playbook-manager/01-playbook-manager-design.md
@@ -1,0 +1,210 @@
+# Playbook Manager Design Document
+
+## Overview
+
+Playbook Manager is a CLI/TUI tool for managing "playbooks" - contextual documents that can be passed as additional context to LLMs to help with work. The tool maintains a central registry of playbooks and collections, allowing users to organize, search, and deploy these documents into workspaces as needed.
+
+## Core Concepts
+
+### Entities
+The system treats both playbooks and collections as first-class entities with identical metadata capabilities:
+
+- **Playbooks**: Individual documents with content (markdown files, guides, standards, etc.)
+- **Collections**: Organized groups of playbooks and/or other collections, enabling hierarchical organization
+
+### Registry
+All data is stored in a single SQLite database (`~/.playbooks/registry.db`) making the system self-contained and portable.
+
+## Database Schema
+
+```sql
+-- Unified entities table (both playbooks and collections)
+CREATE TABLE entities (
+    id INTEGER PRIMARY KEY,
+    type TEXT NOT NULL CHECK (type IN ('playbook', 'collection')),
+    title TEXT NOT NULL,
+    description TEXT,
+    summary TEXT,
+    canonical_url TEXT,              -- NULL for collections, required for playbooks
+    content TEXT,                    -- NULL for collections, required for playbooks
+    content_hash TEXT,               -- NULL for collections
+    filename TEXT,                   -- NULL for collections
+    tags TEXT,                       -- JSON array of tags
+    last_fetched DATETIME,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE entity_metadata (
+    entity_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value TEXT NOT NULL,
+    PRIMARY KEY (entity_id, key)
+);
+
+-- Collection membership (what playbooks/collections are in a collection)
+CREATE TABLE collection_members (
+    collection_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+    member_id INTEGER REFERENCES entities(id) ON DELETE CASCADE,
+    relative_path TEXT,              -- Optional: organize within collection
+    PRIMARY KEY (collection_id, member_id),
+    CHECK ((SELECT type FROM entities WHERE id = collection_id) = 'collection')
+);
+
+CREATE TABLE deployments (
+    id INTEGER PRIMARY KEY,
+    entity_id INTEGER REFERENCES entities(id),
+    target_directory TEXT,
+    deployed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+## Command Line Interface
+
+### Registration and Creation
+
+```bash
+# Register a playbook from file or URL
+pb register <path|url> \
+  --title "Title" \
+  --description "Detailed description" \
+  --summary "Brief summary" \
+  --meta key=value \
+  --meta key2=value2 \
+  --tags tag1,tag2 \
+  --filename override.md
+
+# Create a new collection
+pb create collection "Collection Name" \
+  --title "Display Title" \
+  --description "Purpose and contents" \
+  --summary "Brief overview" \
+  --meta key=value \
+  --tags tag1,tag2
+```
+
+### Discovery and Search
+
+```bash
+# List entities with optional filters
+pb list [--type playbook|collection] [--tags tag1,tag2] [--meta key=value] [--stale]
+
+# Search across titles, descriptions, summaries, and content
+pb search "query" [--type playbook|collection] [--meta-key key] [--in-title] [--in-summary]
+
+# Show detailed information about an entity
+pb show <id>
+```
+
+### Collection Management
+
+```bash
+# Add members to collections
+pb add <collection-id> <playbook-id> [--path subdir/file.md]
+pb add <collection-id> <other-collection-id>
+
+# Remove members from collections
+pb remove <collection-id> <member-id>
+```
+
+### Metadata Management
+
+```bash
+# Set metadata on any entity
+pb meta set <id> <key> <value>
+
+# Get metadata from any entity
+pb meta get <id> [key]
+
+# Remove metadata from any entity
+pb meta remove <id> <key>
+```
+
+### Content Management
+
+```bash
+# Update playbooks from their canonical sources
+pb update <playbook-id|--all>
+
+# Remove entities
+pb remove <id>
+```
+
+### Deployment
+
+```bash
+# Deploy individual playbooks or entire collections
+pb deploy <id> <target-directory> [--filename override.md]
+
+# Check deployment status
+pb status [target-directory]
+```
+
+## Key Features
+
+### Unified Entity Model
+Both playbooks and collections use the same metadata system, making discovery and organization consistent across entity types.
+
+### Rich Metadata System
+- **Core fields**: title, description, summary
+- **Flexible key-value metadata**: repository info, authorship, versioning, categorization
+- **Auto-populated metadata**: source type, file size, fetch dates, git information
+
+### Content Integrity
+- SHA256 hashing of playbook content
+- Change detection for source updates
+- Last fetched timestamps for staleness tracking
+
+### Hierarchical Organization
+- Collections can contain playbooks and other collections
+- Optional relative paths for organizing files within collections
+- Flexible tagging system for cross-cutting categorization
+
+### Self-Contained Storage
+- All content stored directly in SQLite database
+- No external file dependencies
+- Easy backup and synchronization
+
+## Example Workflows
+
+### Basic Playbook Management
+```bash
+# Register a coding standards document
+pb register ./docs/coding-standards.md \
+  --title "Python Coding Standards" \
+  --summary "Style guide and best practices for Python development" \
+  --meta repository=github.com/myorg/standards \
+  --meta version=2.1 \
+  --tags python,standards
+
+# Deploy to workspace
+pb deploy 1 ./my-project/playbooks/
+```
+
+### Collection Organization
+```bash
+# Create a backend development collection
+pb create collection "Backend Development" \
+  --summary "All backend development guidelines and standards" \
+  --meta team=backend \
+  --tags backend,standards
+
+# Add playbooks to the collection
+pb add 2 1  # Add coding standards to backend collection
+pb add 2 3  # Add API guidelines
+pb add 2 4  # Add database standards
+
+# Deploy entire collection
+pb deploy 2 ./new-project/playbooks/
+```
+
+### Discovery and Maintenance
+```bash
+# Find all Python-related content
+pb list --tags python
+
+# Find stale playbooks that might need updates
+pb list --stale
+
+# Update all playbooks from their sources
+pb update --all
+```


### PR DESCRIPTION
This PR introduces the first version of the Playbook Manager, a tool for managing
contextual documents that can be passed to LLMs.

## Core features:
- SQLite-based registry for storing playbooks and collections
- Support for registering playbooks from files, URLs, or shell commands
- Collection management for organizing related playbooks
- Flexible metadata system and tagging
- Deployment capabilities to export playbooks to workspaces
- Search and filtering functionality

## Implementation details:
- Two CLI interfaces:
  - Standard cobra-based CLI (`playbook-manager`)
  - Glazed-based CLI with structured output (`playbook-manager-glazed`)
- Unified entity model for both playbooks and collections
- Content hashing for integrity verification
- Shell command execution support for dynamic content

## Next steps:
- TUI interface for interactive management
- Improved update mechanism for syncing from sources
- Integration with LLM tools