### PR TITLE
Add carapace dynamic completion demo

### DIFF
--- a/cmd/experiments/carapace-dynamic/main.go
+++ b/cmd/experiments/carapace-dynamic/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/carapace-sh/carapace"
+	"github.com/spf13/cobra"
+)
+
+func fetchItems() []string {
+	// In a real app, fetch from DB, API, etc.
+	return []string{"apple", "banana", "cherry", "date"}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "carapace-dynamic",
+	Short: "Demo CLI with dynamic carapace completion",
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list [item]",
+	Short: "List objects from the server",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fmt.Printf("You selected: %s\n", args[0])
+		return nil
+	},
+}
+
+func init() {
+	carapace.Gen(rootCmd).Standalone() // enables _carapace and disables legacy completion
+
+	carapace.Gen(listCmd).PositionalCompletion(
+		carapace.ActionCallback(func(ctx carapace.Context) carapace.Action {
+			items := fetchItems()
+			return carapace.ActionValues(items...)
+		}),
+	)
+
+	rootCmd.AddCommand(listCmd)
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.68.0
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.37.1
 	github.com/blevesearch/bleve v1.0.14
+	github.com/carapace-sh/carapace v1.8.3
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/gum v0.11.0
@@ -144,6 +145,7 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.1 // indirect
 	github.com/blevesearch/zapx/v15 v15.4.1 // indirect
 	github.com/blevesearch/zapx/v16 v16.2.2 // indirect
+	github.com/carapace-sh/carapace-shlex v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.3.0 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,10 @@ github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx2
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
 github.com/bytedance/sonic v1.9.1 h1:6iJ6NqdoxCDr6mbY8h18oSO+cShGSMRGCEo7F2h0x8s=
 github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZXU064P/U=
+github.com/carapace-sh/carapace v1.8.3 h1:dgRqEKHDt33PqJpHhZNIhxjq3PrrU1mUfLWgdAp2WNc=
+github.com/carapace-sh/carapace v1.8.3/go.mod h1:C0PH0NpNW+Gb2nvnJ8nl2yRvvPxEHqVgYU8fphWGoEg=
+github.com/carapace-sh/carapace-shlex v1.0.1 h1:ww0JCgWpOVuqWG7k3724pJ18Lq8gh5pHQs9j3ojUs1c=
+github.com/carapace-sh/carapace-shlex v1.0.1/go.mod h1:lJ4ZsdxytE0wHJ8Ta9S7Qq0XpjgjU0mdfCqiI2FHx7M=
 github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
 github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=

--- a/ttmp/2025-06-26/01-carapace-dynamic-completion.md
+++ b/ttmp/2025-06-26/01-carapace-dynamic-completion.md
@@ -1,0 +1,95 @@
+### 1 . Install the library & binary once
+
+```bash
+go get github.com/carapace-sh/carapace@latest   # library used in your app
+go install github.com/carapace-sh/carapace-bin@latest   # helper binary users will source
+```
+
+Add the helper to every shell you care about (it registers *all* completers in one shot):
+
+````bash
+# ~/.bashrc  (zsh/fish have equivalent one-liners)
+export CARAPACE_BRIDGES='zsh,fish,bash,inshellisense'   # optional
+source <(carapace _carapace)
+``` :contentReference[oaicite:0]{index=0}
+
+---
+
+### 2 . Wire Carapace into your root command
+
+```go
+// cmd/root.go
+var rootCmd = &cobra.Command{
+    Use:   "my-cmd",
+    Short: "Demo CLI with dynamic completion",
+}
+
+// one line enables the hidden “_carapace” sub-command
+// *and* disables Cobra’s legacy completion that would otherwise interfere.
+func init() {
+    carapace.Gen(rootCmd).Standalone()               // 🡅 note Standalone docs :contentReference[oaicite:1]{index=1}
+}
+````
+
+---
+
+### 3 . Add a `list` sub-command with **dynamic** positional completion
+
+```go
+// cmd/list.go
+var listCmd = &cobra.Command{
+    Use:   "list [item]",
+    Short: "List objects from the server",
+    Args:  cobra.ExactArgs(1),
+    RunE: func(cmd *cobra.Command, args []string) error {
+        return runList(args[0])
+    },
+}
+
+func init() {
+    rootCmd.AddCommand(listCmd)
+
+    // #1 — callback that talks to Go code (DB, API, etc.)
+    carapace.Gen(listCmd).PositionalCompletion(
+        carapace.ActionCallback(func(ctx carapace.Context) carapace.Action {
+            items := fetchItems()            // your own func returning []string
+            return carapace.ActionValues(items...)
+        }),
+    )
+}
+```
+
+`ActionCallback` is evaluated **only when TAB is pressed**, so the list is always fresh. ([pkg.go.dev][1])
+
+---
+
+### 4 . Alternative: call an external program for the list
+
+When you already have a helper that prints JSON / lines to stdout:
+
+```go
+carapace.Gen(listCmd).PositionalCompletion(
+    carapace.ActionExecCommand("my-cmd", "list-ids", "--raw")( // run helper
+        func(out []byte) carapace.Action {
+            lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+            return carapace.ActionValues(lines...)
+        }),
+)
+```
+
+`ActionExecCommand` runs the process and converts its output into completion values. ([pkg.go.dev][1])
+
+---
+
+### 5 . Build & test
+
+```bash
+go install ./cmd/my-cmd
+exec $SHELL                    # reload rc file once
+
+my-cmd list <TAB>              # should show the dynamic list
+```
+
+That’s all—Carapace now keeps your completions in step with whatever your backend returns, across Bash, Zsh, Fish, PowerShell, Nushell, etc., without writing a single shell-specific script.
+
+[1]: https://pkg.go.dev/github.com/carapace-sh/carapace?utm_source=chatgpt.com "carapace package - github.com/carapace-sh/carapace - Go Packages"


### PR DESCRIPTION
## Overview

Adds experimental demo showcasing dynamic shell completion using the carapace
library.

## Changes

• **Demo CLI application**: Creates `carapace-dynamic` command with dynamic 
  completion
• **Dynamic completion**: Implements callback-based completion that fetches 
  items at TAB-press time
• **Multi-shell support**: Works across bash, zsh, fish, and other shells 
  through carapace
• **Documentation**: Comprehensive guide covering installation, setup, and 
  usage patterns

## Implementation Details

• Uses `carapace.ActionCallback` for runtime completion generation
• Demonstrates fetching completion values from functions (simulating DB/API 
  calls)
• Shows alternative approach using external command execution
• Includes standalone mode setup to disable cobra's legacy completion

## Testing

Build and test the demo:
```bash
go install ./cmd/experiments/carapace-dynamic
carapace-dynamic list <TAB>  # shows: apple, banana, cherry, date
```