### PR TITLE
Add PR analyzer tool

### DIFF
--- a/cmd/apps/go-build-analyzer/README.md
+++ b/cmd/apps/go-build-analyzer/README.md
@@ -1,0 +1,282 @@
+## Go Build Analyzer
+
+A toolexec wrapper and CLI that logs every Go tool invocation (compile, asm, pack, link, etc.) to SQLite and provides Glazed-based commands to explore runs, invocations, and performance stats.
+
+This README gives you a fast start and a tour of the features with runnable examples.
+
+### What you get
+
+- **Toolexec wrapper**: Transparent, best-effort logging without changing build outcomes.
+- **SQLite backend (pure Go)**: Uses `modernc.org/sqlite`; no CGO required.
+- **Runs and invocations**: Group invocations per build “run” with optional comments.
+- **Rich metadata**: Package `-p`, outputs, importcfg, buildid, Go/lang versions, OS/arch, CWD, concurrency, flags JSON, elapsed time, status.
+- **Glazed CLI**: Structured output with `--output table|json|yaml|csv`, `--fields`, `--sort-columns`.
+
+---
+
+## Prerequisites
+
+- Go 1.24+ (workspace uses a `go.work` with 1.24.3)
+- Linux/macOS shell with `bash`, `sed`, `jq` (for script demos)
+
+Optional:
+- `sqlite3` CLI for ad‑hoc SQL queries
+
+---
+
+## Install / Build
+
+From the repo root:
+
+```bash
+cd go-go-labs/cmd/apps/go-build-analyzer
+go build -o ./go-build-analyzer .
+```
+
+You can also run the helper:
+
+```bash
+./scripts/01-build-binary.sh
+```
+
+The binary path printed by the script can be used with `-toolexec`.
+
+---
+
+## Quick Start
+
+1) Create a run and export environment variables:
+
+```bash
+./scripts/02-new-run-and-export.sh
+# prints TOOLEXEC_DB=... and TOOLEXEC_RUN_ID=...
+```
+
+- `TOOLEXEC_DB` (optional): path to `build_times.db` (defaults to repo root if unset)
+- `TOOLEXEC_RUN_ID`: groups subsequent invocations under a single run
+
+2) Perform a clean, instrumented build across both modules:
+
+```bash
+./scripts/03-instrumented-build.sh
+```
+
+3) Explore data:
+
+```bash
+# List runs
+./go-build-analyzer runs-list --output table
+
+# Top packages by compile time (latest run)
+./scripts/11-top-packages.sh
+
+# Recent compile invocations (table + json)
+./scripts/12-invocations-sample.sh
+
+# Filter by package
+./scripts/13-invocations-by-pkg.sh github.com/go-go-golems/glazed/pkg/cmds/parameters
+
+# Export JSONL for downstream tools
+./scripts/14-export-jsonl.sh
+```
+
+At any time, switch output formats:
+
+```bash
+./go-build-analyzer stats-packages --run-id 3 --tool compile --limit 30 --output json
+./go-build-analyzer invocations-list --run-id 3 --tool compile --limit 10 --output csv
+```
+
+---
+
+## Command Tour
+
+All commands support Glazed output flags such as `--output`, `--fields`, and `--sort-columns`.
+
+- `runs-new`
+  - Create a new run. Use `--comment` to annotate and `--print-env` to echo an `export TOOLEXEC_RUN_ID=...` snippet.
+  - Example:
+    ```bash
+    ./go-build-analyzer runs-new --comment "full rebuild" --print-env --output table
+    ```
+
+- `runs-list`
+  - List runs with `run_id`, timestamp, and comment.
+  - Example:
+    ```bash
+    ./go-build-analyzer runs-list --output table
+    ```
+
+- `invocations-list`
+  - List tool invocations with rich metadata. Filters: `--run-id`, `--tool`, `--pkg`, `--limit`.
+  - Useful fields include: `tool`, `tool_path`, `pkg`, `status`, `elapsed_ms`, `os`, `arch`, `cwd`, `out`, `importcfg`, `embedcfg`, `buildid`, `goversion`, `lang`, `concurrency`, `complete`, `pack`, `source_count`, `flags_json`, `args`.
+  - Example:
+    ```bash
+    ./go-build-analyzer invocations-list --run-id 3 --tool compile --limit 20 --output table
+    ```
+
+- `stats-packages`
+  - Aggregate elapsed times by package for a tool (default `compile`).
+  - Filters: `--run-id`, `--tool`, `--limit`.
+  - Example:
+    ```bash
+    ./go-build-analyzer stats-packages --run-id 3 --tool compile --limit 30 --output table
+    ```
+
+---
+
+## Data Model
+
+Two tables are created in SQLite:
+
+### `runs`
+- `id` (PK), `ts_unix`, `comment`
+
+### `invocations`
+- Core: `id`, `run_id`, `ts_unix`, `tool`, `status`, `elapsed_ms`, `args`
+- Identity: `tool_path`, `pkg`
+- Platform/context: `os`, `arch`, `cwd`
+- Compile/link flags: `out`, `importcfg`, `embedcfg`, `buildid`, `goversion`, `lang`, `concurrency`, `complete`, `pack`, `source_count`
+- Raw parsed flags as JSON: `flags_json`
+
+Foreign keys and indexes make querying by `run_id`, `tool`, `pkg`, and time efficient.
+
+---
+
+## Using with `go build -toolexec`
+
+You can run the analyzer directly as the toolexec program. Ensure `TOOLEXEC_DB` and (optionally) `TOOLEXEC_RUN_ID` are set.
+
+```bash
+export TOOLEXEC_DB="$(pwd)/build_times.db"
+export TOOLEXEC_RUN_ID=123
+go clean -cache
+go build -a -toolexec="$(pwd)/go-build-analyzer" ./...
+```
+
+The wrapper will:
+- Run the real tool binary
+- Measure wall time
+- Parse flags (e.g., `-p`, `-o`, `-importcfg`, `-buildid`, `-lang`, `-goversion`, `-c`)
+- Record a row in `invocations` without affecting the exit code
+
+---
+
+## Using with `go test`
+
+You can benchmark build time incurred by `go test`. The wrapper logs compile/link steps triggered by tests (including dependencies). Test execution time itself is not recorded.
+
+### Minimal workflow
+
+```bash
+# 1) Choose DB and create a run; export RUN_ID for this shell
+export TOOLEXEC_DB="$(pwd)/build_times.db"
+eval "$(./go-build-analyzer runs-new --comment 'go test build' --print-env | grep '^export ')"
+
+# 2) Avoid caches masking build work
+go clean -cache -testcache
+
+# 3a) Compile test binaries only (build-time focus)
+go test -count=1 -c ./... -toolexec="$(pwd)/go-build-analyzer"
+
+# 3b) Or run tests (still records the build steps)
+go test -count=1 ./... -toolexec="$(pwd)/go-build-analyzer"
+```
+
+### Useful queries
+
+```bash
+# Top compile-time packages for this run
+./go-build-analyzer stats-packages --run-id "$TOOLEXEC_RUN_ID" --tool compile --limit 50 --output table
+
+# Recent compile/link steps
+./go-build-analyzer invocations-list --run-id "$TOOLEXEC_RUN_ID" --tool compile --limit 50 --output table
+./go-build-analyzer invocations-list --run-id "$TOOLEXEC_RUN_ID" --tool link --limit 50 --output table
+
+# Approximate test-only binaries (linked test mains often end with _test)
+./go-build-analyzer invocations-list --run-id "$TOOLEXEC_RUN_ID" --tool link --limit 500 --output json \
+| jq -r '.[] | select(.out | test("_test$")) | {out, pkg, elapsed_ms, args}'
+
+# Export everything for offline analysis
+./go-build-analyzer invocations-list --run-id "$TOOLEXEC_RUN_ID" --limit 100000 --output json \
+| jq -c '.[]' > "invocations-run-$TOOLEXEC_RUN_ID.jsonl"
+```
+
+### CI tips
+
+- Use `-count=1` and `go clean -cache -testcache` to minimize cache effects.
+- Prefer `go test -c` when you want to exclude test execution time and focus purely on build cost.
+- Separate first-party vs third-party by filtering `pkg` prefixes in queries.
+
+## Demo Scripts
+
+Scripts live in `scripts/` and are safe to run repeatedly:
+
+- `01-build-binary.sh`: Compile the analyzer.
+- `02-new-run-and-export.sh`: Create a new run and export `TOOLEXEC_*` env vars.
+- `03-instrumented-build.sh`: Clean cache and build both modules with `-toolexec` (continues on failures to capture logs).
+- `10-query-runs.sh`: Show runs in table and JSON.
+- `11-top-packages.sh`: Top packages by compile time for the latest run.
+- `12-invocations-sample.sh`: Recent compile invocations (table + JSON).
+- `13-invocations-by-pkg.sh <pkg>`: Filter invocations by package.
+- `14-export-jsonl.sh`: Export invocations for the latest run as JSONL.
+
+Example one‑liner tour:
+
+```bash
+./scripts/01-build-binary.sh && \
+./scripts/02-new-run-and-export.sh && \
+./scripts/03-instrumented-build.sh && \
+./scripts/10-query-runs.sh && \
+./scripts/11-top-packages.sh && \
+./scripts/12-invocations-sample.sh && \
+./scripts/14-export-jsonl.sh
+```
+
+---
+
+## Ad‑hoc SQL
+
+You can run custom SQL against the DB for dashboards and notebooks.
+
+```sql
+-- Top 30 packages by compile time for a given run
+SELECT pkg, SUM(elapsed_ms) AS total_ms, COUNT(*) AS n
+FROM invocations
+WHERE tool = 'compile' AND run_id = :run
+GROUP BY pkg
+ORDER BY total_ms DESC
+LIMIT 30;
+
+-- Per-tool breakdown for the run
+SELECT tool, SUM(elapsed_ms) AS total_ms, COUNT(*) AS n
+FROM invocations
+WHERE run_id = :run
+GROUP BY tool
+ORDER BY total_ms DESC;
+```
+
+---
+
+## Tips, Caveats, Troubleshooting
+
+- This tool logs best‑effort; it must never change build behavior. If logging fails, builds continue.
+- Some experimental packages may fail to build (e.g., missing generated object files); logs are still recorded.
+- `flags_json` contains all parsed flags for post‑hoc analysis. Consider extracting dimensions you need for dashboards.
+- Use Glazed options to tailor output:
+  - `--fields pkg,total_ms`
+  - `--sort-columns -total_ms`
+  - `--output json|yaml|csv|table`
+
+---
+
+## Learn More (Style & Help)
+
+- Documentation style: see `glazed/pkg/doc/topics/how-to-write-good-documentation-pages.md`
+- Glazed help: if you embed this in a larger app with help, you can follow patterns like:
+  ```bash
+  glaze help commands-reference
+  glaze help layers-guide
+  ```
+
+

--- a/cmd/apps/go-build-analyzer/cli.go
+++ b/cmd/apps/go-build-analyzer/cli.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/go-go-golems/glazed/pkg/cli"
+	"github.com/go-go-golems/glazed/pkg/cmds"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+	"github.com/go-go-golems/glazed/pkg/help"
+	help_cmd "github.com/go-go-golems/glazed/pkg/help/cmd"
+	"github.com/go-go-golems/glazed/pkg/middlewares"
+	"github.com/go-go-golems/glazed/pkg/settings"
+	"github.com/go-go-golems/glazed/pkg/types"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func runCLI(ctx context.Context) {
+    rootCmd := &cobra.Command{
+        Use:   "go-build-analyzer",
+        Short: "Analyze Go build tool invocations and timings",
+        Long:  "Toolexec wrapper and query CLI for analyzing Go build timings stored in SQLite.",
+    }
+
+    // Build commands
+    commands := []cmds.Command{ }
+
+    // runs new
+    if c, err := NewRunsNewCommand(); err == nil {
+        commands = append(commands, c)
+    } else {
+        fmt.Fprintln(os.Stderr, "error creating command runs new:", err)
+    }
+    // runs list
+    if c, err := NewRunsListCommand(); err == nil {
+        commands = append(commands, c)
+    } else {
+        fmt.Fprintln(os.Stderr, "error creating command runs list:", err)
+    }
+    // invocations list
+    if c, err := NewInvocationsListCommand(); err == nil {
+        commands = append(commands, c)
+    } else {
+        fmt.Fprintln(os.Stderr, "error creating command invocations list:", err)
+    }
+    // stats packages
+    if c, err := NewStatsPackagesCommand(); err == nil {
+        commands = append(commands, c)
+    } else {
+        fmt.Fprintln(os.Stderr, "error creating command stats packages:", err)
+    }
+
+    // Add as cobra subcommands
+    for _, gc := range commands {
+        cobraCmd, err := cli.BuildCobraCommand(gc,
+            cli.WithParserConfig(cli.CobraParserConfig{
+                ShortHelpLayers: []string{layers.DefaultSlug},
+                MiddlewaresFunc: cli.CobraCommandDefaultMiddlewares,
+            }),
+        )
+        if err != nil {
+            fmt.Fprintln(os.Stderr, "error building cobra command:", err)
+            os.Exit(1)
+        }
+        rootCmd.AddCommand(cobraCmd)
+    }
+
+    // Enhanced help system
+    helpSystem := help.NewHelpSystem()
+    help_cmd.SetupCobraRootCommand(helpSystem, rootCmd)
+
+    if err := rootCmd.Execute(); err != nil {
+        os.Exit(1)
+    }
+}
+
+// runs new
+type RunsNewCommand struct {
+    *cmds.CommandDescription
+}
+
+type RunsNewSettings struct {
+    Comment string `glazed.parameter:"comment"`
+    PrintEnv bool   `glazed.parameter:"print-env"`
+}
+
+func NewRunsNewCommand() (*RunsNewCommand, error) {
+    glazedLayer, err := settings.NewGlazedParameterLayers()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+    commandSettingsLayer, err := cli.NewCommandSettingsLayer()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+
+    cd := cmds.NewCommandDescription(
+        "runs-new",
+        cmds.WithShort("Create a new build run and return its id"),
+        cmds.WithFlags(
+            parameters.NewParameterDefinition("comment", parameters.ParameterTypeString, parameters.WithDefault(""), parameters.WithHelp("Optional run comment")),
+            parameters.NewParameterDefinition("print-env", parameters.ParameterTypeBool, parameters.WithDefault(false), parameters.WithHelp("Print shell export for TOOLEXEC_RUN_ID")),
+        ),
+        cmds.WithLayersList(glazedLayer, commandSettingsLayer),
+    )
+    return &RunsNewCommand{CommandDescription: cd}, nil
+}
+
+var _ cmds.GlazeCommand = &RunsNewCommand{}
+
+func (c *RunsNewCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    s := &RunsNewSettings{}
+    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+        return errors.WithStack(err)
+    }
+
+    db, err := openDB(ctx)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer db.Close()
+
+    id, err := insertRun(ctx, db, s.Comment)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+
+    if s.PrintEnv {
+        fmt.Printf("export TOOLEXEC_RUN_ID=%d\n", id)
+    }
+
+    row := types.NewRow(
+        types.MRP("run_id", id),
+        types.MRP("comment", s.Comment),
+    )
+    return gp.AddRow(ctx, row)
+}
+
+// runs list
+type RunsListCommand struct {
+    *cmds.CommandDescription
+}
+
+func NewRunsListCommand() (*RunsListCommand, error) {
+    glazedLayer, err := settings.NewGlazedParameterLayers()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+    commandSettingsLayer, err := cli.NewCommandSettingsLayer()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+
+    cd := cmds.NewCommandDescription(
+        "runs-list",
+        cmds.WithShort("List recorded runs"),
+        cmds.WithLayersList(glazedLayer, commandSettingsLayer),
+    )
+    return &RunsListCommand{CommandDescription: cd}, nil
+}
+
+var _ cmds.GlazeCommand = &RunsListCommand{}
+
+func (c *RunsListCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    db, err := openDB(ctx)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer db.Close()
+
+    rows, err := db.QueryContext(ctx, `SELECT id, ts_unix, comment FROM runs ORDER BY id DESC`)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer rows.Close()
+
+    for rows.Next() {
+        var id int64
+        var ts int64
+        var comment string
+        if err := rows.Scan(&id, &ts, &comment); err != nil {
+            return errors.WithStack(err)
+        }
+        r := types.NewRow(
+            types.MRP("run_id", id),
+            types.MRP("ts_unix", ts),
+            types.MRP("comment", comment),
+        )
+        if err := gp.AddRow(ctx, r); err != nil {
+            return errors.WithStack(err)
+        }
+    }
+    return nil
+}
+
+// invocations list
+type InvocationsListCommand struct {
+    *cmds.CommandDescription
+}
+
+type InvocationsListSettings struct {
+    RunID  int64  `glazed.parameter:"run-id"`
+    Tool   string `glazed.parameter:"tool"`
+    Pkg    string `glazed.parameter:"pkg"`
+    Limit  int    `glazed.parameter:"limit"`
+}
+
+func NewInvocationsListCommand() (*InvocationsListCommand, error) {
+    glazedLayer, err := settings.NewGlazedParameterLayers()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+    commandSettingsLayer, err := cli.NewCommandSettingsLayer()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+
+    cd := cmds.NewCommandDescription(
+        "invocations-list",
+        cmds.WithShort("List tool invocations, optionally filtered"),
+        cmds.WithFlags(
+            parameters.NewParameterDefinition("run-id", parameters.ParameterTypeInteger, parameters.WithDefault(0), parameters.WithHelp("Filter by run id (>0)")),
+            parameters.NewParameterDefinition("tool", parameters.ParameterTypeString, parameters.WithDefault(""), parameters.WithHelp("Filter by tool name")),
+            parameters.NewParameterDefinition("pkg", parameters.ParameterTypeString, parameters.WithDefault(""), parameters.WithHelp("Filter by package")),
+            parameters.NewParameterDefinition("limit", parameters.ParameterTypeInteger, parameters.WithDefault(200), parameters.WithHelp("Limit number of rows")),
+        ),
+        cmds.WithLayersList(glazedLayer, commandSettingsLayer),
+    )
+    return &InvocationsListCommand{CommandDescription: cd}, nil
+}
+
+var _ cmds.GlazeCommand = &InvocationsListCommand{}
+
+func (c *InvocationsListCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    s := &InvocationsListSettings{}
+    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+        return errors.WithStack(err)
+    }
+
+    db, err := openDB(ctx)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer db.Close()
+
+    q := "SELECT id, run_id, ts_unix, tool, tool_path, pkg, status, elapsed_ms, args, os, arch, cwd, out, importcfg, embedcfg, buildid, goversion, lang, concurrency, complete, pack, source_count, flags_json FROM invocations"
+    var where []string
+    var args []any
+    if s.RunID > 0 {
+        where = append(where, "run_id = ?")
+        args = append(args, s.RunID)
+    }
+    if s.Tool != "" {
+        where = append(where, "tool = ?")
+        args = append(args, s.Tool)
+    }
+    if s.Pkg != "" {
+        where = append(where, "pkg = ?")
+        args = append(args, s.Pkg)
+    }
+    if len(where) > 0 {
+        q += " WHERE " + stringsJoin(where, " AND ")
+    }
+    q += " ORDER BY id DESC"
+    if s.Limit > 0 {
+        q += fmt.Sprintf(" LIMIT %d", s.Limit)
+    }
+
+    rows, err := db.QueryContext(ctx, q, args...)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer rows.Close()
+
+    for rows.Next() {
+        var id, runID, ts int64
+        var tool, toolPath, pkg string
+        var status, elapsed int64
+        var argstr string
+        var osStr, archStr, cwd, out, importcfg, embedcfg, buildid, goversion, lang string
+        var concurrency, complete, pack, sourceCount int64
+        var flagsJSON string
+        if err := rows.Scan(&id, &runID, &ts, &tool, &toolPath, &pkg, &status, &elapsed, &argstr, &osStr, &archStr, &cwd, &out, &importcfg, &embedcfg, &buildid, &goversion, &lang, &concurrency, &complete, &pack, &sourceCount, &flagsJSON); err != nil {
+            return errors.WithStack(err)
+        }
+        r := types.NewRow(
+            types.MRP("id", id),
+            types.MRP("run_id", runID),
+            types.MRP("ts_unix", ts),
+            types.MRP("tool", tool),
+            types.MRP("tool_path", toolPath),
+            types.MRP("pkg", pkg),
+            types.MRP("status", status),
+            types.MRP("elapsed_ms", elapsed),
+            types.MRP("args", argstr),
+            types.MRP("os", osStr),
+            types.MRP("arch", archStr),
+            types.MRP("cwd", cwd),
+            types.MRP("out", out),
+            types.MRP("importcfg", importcfg),
+            types.MRP("embedcfg", embedcfg),
+            types.MRP("buildid", buildid),
+            types.MRP("goversion", goversion),
+            types.MRP("lang", lang),
+            types.MRP("concurrency", concurrency),
+            types.MRP("complete", complete),
+            types.MRP("pack", pack),
+            types.MRP("source_count", sourceCount),
+            types.MRP("flags_json", flagsJSON),
+        )
+        if err := gp.AddRow(ctx, r); err != nil {
+            return errors.WithStack(err)
+        }
+    }
+    return nil
+}
+
+// stats packages (sum elapsed for compile by pkg)
+type StatsPackagesCommand struct {
+    *cmds.CommandDescription
+}
+
+type StatsPackagesSettings struct {
+    RunID int64 `glazed.parameter:"run-id"`
+    Tool  string `glazed.parameter:"tool"`
+    Limit int   `glazed.parameter:"limit"`
+}
+
+func NewStatsPackagesCommand() (*StatsPackagesCommand, error) {
+    glazedLayer, err := settings.NewGlazedParameterLayers()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+    commandSettingsLayer, err := cli.NewCommandSettingsLayer()
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+
+    cd := cmds.NewCommandDescription(
+        "stats-packages",
+        cmds.WithShort("Aggregate elapsed time by package (default tool=compile)"),
+        cmds.WithFlags(
+            parameters.NewParameterDefinition("run-id", parameters.ParameterTypeInteger, parameters.WithDefault(0), parameters.WithHelp("Filter by run id (>0)")),
+            parameters.NewParameterDefinition("tool", parameters.ParameterTypeString, parameters.WithDefault("compile"), parameters.WithHelp("Tool to aggregate (compile/link/asm/etc)")),
+            parameters.NewParameterDefinition("limit", parameters.ParameterTypeInteger, parameters.WithDefault(50), parameters.WithHelp("Limit number of rows")),
+        ),
+        cmds.WithLayersList(glazedLayer, commandSettingsLayer),
+    )
+    return &StatsPackagesCommand{CommandDescription: cd}, nil
+}
+
+var _ cmds.GlazeCommand = &StatsPackagesCommand{}
+
+func (c *StatsPackagesCommand) RunIntoGlazeProcessor(ctx context.Context, parsedLayers *layers.ParsedLayers, gp middlewares.Processor) error {
+    s := &StatsPackagesSettings{}
+    if err := parsedLayers.InitializeStruct(layers.DefaultSlug, s); err != nil {
+        return errors.WithStack(err)
+    }
+
+    db, err := openDB(ctx)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer db.Close()
+
+    q := "SELECT pkg, SUM(elapsed_ms) AS total_ms, COUNT(*) AS num FROM invocations WHERE tool = ?"
+    var args []any
+    args = append(args, s.Tool)
+    if s.RunID > 0 {
+        q += " AND run_id = ?"
+        args = append(args, s.RunID)
+    }
+    q += " GROUP BY pkg ORDER BY total_ms DESC"
+    if s.Limit > 0 {
+        q += fmt.Sprintf(" LIMIT %d", s.Limit)
+    }
+
+    rows, err := db.QueryContext(ctx, q, args...)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer rows.Close()
+
+    for rows.Next() {
+        var pkg string
+        var totalMs int64
+        var num int64
+        if err := rows.Scan(&pkg, &totalMs, &num); err != nil {
+            return errors.WithStack(err)
+        }
+        r := types.NewRow(
+            types.MRP("pkg", pkg),
+            types.MRP("total_ms", totalMs),
+            types.MRP("num", num),
+        )
+        if err := gp.AddRow(ctx, r); err != nil {
+            return errors.WithStack(err)
+        }
+    }
+    return nil
+}
+
+// Utility: join without importing strings (we already have a strings usage in another file)
+func stringsJoin(parts []string, sep string) string {
+    if len(parts) == 0 {
+        return ""
+    }
+    out := parts[0]
+    for i := 1; i < len(parts); i++ {
+        out += sep + parts[i]
+    }
+    return out
+}
+
+

--- a/cmd/apps/go-build-analyzer/db.go
+++ b/cmd/apps/go-build-analyzer/db.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+	_ "modernc.org/sqlite"
+)
+
+func getDBPath() string {
+    if p := os.Getenv("TOOLEXEC_DB"); p != "" {
+        return p
+    }
+    return "./build_times.db"
+}
+
+func openDB(ctx context.Context) (*sql.DB, error) {
+    dsn := getDBPath() + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout=5000"
+    db, err := sql.Open("sqlite", dsn)
+    if err != nil {
+        return nil, errors.WithStack(err)
+    }
+    // Quick ping to validate
+    if err := db.PingContext(ctx); err != nil {
+        _ = db.Close()
+        return nil, errors.WithStack(err)
+    }
+    if err := ensureSchema(db); err != nil {
+        _ = db.Close()
+        return nil, errors.WithStack(err)
+    }
+    return db, nil
+}
+
+func ensureSchema(db *sql.DB) error {
+    _, err := db.Exec(`
+CREATE TABLE IF NOT EXISTS runs (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts_unix   INTEGER NOT NULL,
+  comment   TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_runs_ts ON runs(ts_unix);
+
+CREATE TABLE IF NOT EXISTS invocations (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id       INTEGER,
+  ts_unix      INTEGER NOT NULL,
+  tool         TEXT    NOT NULL,
+  tool_path    TEXT    NOT NULL DEFAULT '',
+  pkg          TEXT    NOT NULL,
+  status       INTEGER NOT NULL,
+  elapsed_ms   INTEGER NOT NULL,
+  args         TEXT    NOT NULL,
+  os           TEXT    NOT NULL DEFAULT '',
+  arch         TEXT    NOT NULL DEFAULT '',
+  cwd          TEXT    NOT NULL DEFAULT '',
+  out          TEXT    NOT NULL DEFAULT '',
+  importcfg    TEXT    NOT NULL DEFAULT '',
+  embedcfg     TEXT    NOT NULL DEFAULT '',
+  buildid      TEXT    NOT NULL DEFAULT '',
+  goversion    TEXT    NOT NULL DEFAULT '',
+  lang         TEXT    NOT NULL DEFAULT '',
+  concurrency  INTEGER NOT NULL DEFAULT 0,
+  complete     INTEGER NOT NULL DEFAULT 0,
+  pack         INTEGER NOT NULL DEFAULT 0,
+  source_count INTEGER NOT NULL DEFAULT 0,
+  flags_json   TEXT    NOT NULL DEFAULT '',
+  FOREIGN KEY (run_id) REFERENCES runs(id)
+);
+CREATE INDEX IF NOT EXISTS idx_inv_tool_ts ON invocations(tool, ts_unix);
+CREATE INDEX IF NOT EXISTS idx_inv_pkg_ts  ON invocations(pkg, ts_unix);
+CREATE INDEX IF NOT EXISTS idx_inv_run_ts  ON invocations(run_id, ts_unix);
+`)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+
+    // Additive migrations for existing DBs (best-effort)
+    // Each ALTER is idempotent-ish: ignore errors if the column already exists
+    alters := []string{
+        `ALTER TABLE invocations ADD COLUMN tool_path TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN os TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN arch TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN cwd TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN out TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN importcfg TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN embedcfg TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN buildid TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN goversion TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN lang TEXT NOT NULL DEFAULT ''`,
+        `ALTER TABLE invocations ADD COLUMN concurrency INTEGER NOT NULL DEFAULT 0`,
+        `ALTER TABLE invocations ADD COLUMN complete INTEGER NOT NULL DEFAULT 0`,
+        `ALTER TABLE invocations ADD COLUMN pack INTEGER NOT NULL DEFAULT 0`,
+        `ALTER TABLE invocations ADD COLUMN source_count INTEGER NOT NULL DEFAULT 0`,
+        `ALTER TABLE invocations ADD COLUMN flags_json TEXT NOT NULL DEFAULT ''`,
+    }
+    for _, q := range alters {
+        if _, e := db.Exec(q); e != nil {
+            // ignore; likely exists
+        }
+    }
+    return nil
+}
+
+func insertRun(ctx context.Context, db *sql.DB, comment string) (int64, error) {
+    res, err := db.ExecContext(ctx, `INSERT INTO runs (ts_unix, comment) VALUES (?, ?)`, time.Now().Unix(), comment)
+    if err != nil {
+        return 0, errors.WithStack(err)
+    }
+    id, err := res.LastInsertId()
+    if err != nil {
+        return 0, errors.WithStack(err)
+    }
+    return id, nil
+}
+
+func currentRunID() (int64, bool) {
+    // Prefer TOOLEXEC_RUN_ID; fall back to GO_BUILD_ANALYZER_RUN_ID
+    if s := os.Getenv("TOOLEXEC_RUN_ID"); s != "" {
+        if v, err := strconv.ParseInt(s, 10, 64); err == nil && v > 0 {
+            return v, true
+        }
+    }
+    if s := os.Getenv("GO_BUILD_ANALYZER_RUN_ID"); s != "" {
+        if v, err := strconv.ParseInt(s, 10, 64); err == nil && v > 0 {
+            return v, true
+        }
+    }
+    return 0, false
+}
+
+

--- a/cmd/apps/go-build-analyzer/go.moddoc.txt
+++ b/cmd/apps/go-build-analyzer/go.moddoc.txt
@@ -1,0 +1,2 @@
+This app uses the parent module (go-go-labs). No separate go.mod.
+

--- a/cmd/apps/go-build-analyzer/main.go
+++ b/cmd/apps/go-build-analyzer/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+)
+
+func main() {
+    // Decide whether we're invoked as a toolexec wrapper (first arg is a tool path)
+    if isWrapperInvocation() {
+        runWrapper()
+        return
+    }
+
+    // Otherwise, run the CLI for querying and managing runs
+    runCLI(context.Background())
+}
+
+

--- a/cmd/apps/go-build-analyzer/scripts/01-build-binary.sh
+++ b/cmd/apps/go-build-analyzer/scripts/01-build-binary.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the analyzer binary in-place
+cd "$(dirname "$0")/.."
+go build -o ./go-build-analyzer .
+echo "Built: $(realpath ./go-build-analyzer)"
+
+

--- a/cmd/apps/go-build-analyzer/scripts/02-new-run-and-export.sh
+++ b/cmd/apps/go-build-analyzer/scripts/02-new-run-and-export.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+DB_PATH="${TOOLEXEC_DB:-$(realpath ../../../../build_times.db)}"
+
+export TOOLEXEC_DB="$DB_PATH"
+RUN_JSON="$($BIN runs-new --comment "scripted run $(date -u +%FT%TZ)" --output json)"
+RUN_ID="$(printf '%s' "$RUN_JSON" | sed -n 's/.*"run_id":[ ]*\([0-9]*\).*/\1/p')"
+export TOOLEXEC_RUN_ID="$RUN_ID"
+
+echo "TOOLEXEC_DB=$TOOLEXEC_DB"
+echo "TOOLEXEC_RUN_ID=$TOOLEXEC_RUN_ID"

--- a/cmd/apps/go-build-analyzer/scripts/03-instrumented-build.sh
+++ b/cmd/apps/go-build-analyzer/scripts/03-instrumented-build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve important paths (repo root contains both glazed and go-go-labs)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$(realpath "$SCRIPT_DIR/..")"
+REPO_ROOT="$(realpath "$APP_DIR/../../../..")"
+BIN_PATH="$(realpath "$APP_DIR/go-build-analyzer")"
+
+if [[ ! -x "$BIN_PATH" ]]; then
+  echo "Analyzer binary not found at $BIN_PATH. Run scripts/01-build-binary.sh first." >&2
+  exit 1
+fi
+
+pushd "$REPO_ROOT" >/dev/null
+
+go clean -cache || true
+
+pushd glazed >/dev/null
+  go build -a -toolexec="$BIN_PATH" ./... || true
+popd >/dev/null
+
+pushd go-go-labs >/dev/null
+  go build -a -toolexec="$BIN_PATH" ./... || true
+popd >/dev/null
+
+popd >/dev/null
+
+echo "Instrumented builds completed (some packages may have failed, which is ok for logging)."

--- a/cmd/apps/go-build-analyzer/scripts/10-query-runs.sh
+++ b/cmd/apps/go-build-analyzer/scripts/10-query-runs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+
+echo "# Runs (table)"
+$BIN runs-list --output table
+
+echo
+
+echo "# Runs (json)"
+$BIN runs-list --output json

--- a/cmd/apps/go-build-analyzer/scripts/11-top-packages.sh
+++ b/cmd/apps/go-build-analyzer/scripts/11-top-packages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+
+# get latest run id
+RUN_ID="$($BIN runs-list --output json | jq -r '.[0].run_id')"
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  echo "No runs found. Create one first (scripts/02-new-run-and-export.sh) and build (scripts/03-instrumented-build.sh)." >&2
+  exit 1
+fi
+
+$BIN stats-packages --run-id "$RUN_ID" --tool compile --limit 30 --output table

--- a/cmd/apps/go-build-analyzer/scripts/12-invocations-sample.sh
+++ b/cmd/apps/go-build-analyzer/scripts/12-invocations-sample.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+
+RUN_ID="$($BIN runs-list --output json | jq -r '.[0].run_id')"
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  echo "No runs found. Create one first (scripts/02-new-run-and-export.sh) and build (scripts/03-instrumented-build.sh)." >&2
+  exit 1
+fi
+
+echo "# Recent compile invocations (table)"
+$BIN invocations-list --run-id "$RUN_ID" --tool compile --limit 10 --output table
+
+echo
+
+echo "# Recent compile invocations (json)"
+$BIN invocations-list --run-id "$RUN_ID" --tool compile --limit 5 --output json

--- a/cmd/apps/go-build-analyzer/scripts/13-invocations-by-pkg.sh
+++ b/cmd/apps/go-build-analyzer/scripts/13-invocations-by-pkg.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+PKG_PATTERN="${1:-main}"
+
+RUN_ID="$($BIN runs-list --output json | jq -r '.[0].run_id')"
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  echo "No runs found. Create one first (scripts/02-new-run-and-export.sh) and build (scripts/03-instrumented-build.sh)." >&2
+  exit 1
+fi
+
+$BIN invocations-list --run-id "$RUN_ID" --tool compile --pkg "$PKG_PATTERN" --limit 50 --output table

--- a/cmd/apps/go-build-analyzer/scripts/14-export-jsonl.sh
+++ b/cmd/apps/go-build-analyzer/scripts/14-export-jsonl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+BIN="$(realpath ./go-build-analyzer)"
+RUN_ID="$($BIN runs-list --output json | jq -r '.[0].run_id')"
+
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+  echo "No runs found. Create one first (scripts/02-new-run-and-export.sh) and build (scripts/03-instrumented-build.sh)." >&2
+  exit 1
+fi
+
+OUT="invocations-run-$RUN_ID.jsonl"
+$BIN invocations-list --run-id "$RUN_ID" --limit 100000 --output json | jq -c '.[]' > "$OUT"
+echo "Wrote $OUT"

--- a/cmd/apps/go-build-analyzer/wrapper.go
+++ b/cmd/apps/go-build-analyzer/wrapper.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// isWrapperInvocation returns true if the program seems to be invoked by `go build -toolexec`.
+func isWrapperInvocation() bool {
+    // When used as toolexec, os.Args will include at least: [wrapper, /path/to/tool, ...]
+    if len(os.Args) < 2 {
+        return false
+    }
+    toolPath := os.Args[1]
+    base := filepath.Base(toolPath)
+    if base == "" {
+        return false
+    }
+    // Heuristic: If first arg basename matches a known tool or contains path separators, treat as wrapper
+    switch base {
+    case "compile", "asm", "pack", "link", "cgo", "cover", "vet":
+        return true
+    }
+    if strings.Contains(toolPath, "/") || strings.Contains(toolPath, "\\") {
+        return true
+    }
+    return false
+}
+
+func runWrapper() {
+    args := os.Args[1:]
+    if len(args) == 0 {
+        os.Exit(1)
+    }
+
+    toolPath := args[0]
+    tool := filepath.Base(toolPath)
+
+    // Extract details from tool-specific args
+    toolArgs := []string{}
+    if len(args) > 1 {
+        toolArgs = args[1:]
+    }
+    details := parseToolArgs(tool, toolArgs)
+
+    // Execute the tool
+    start := time.Now()
+    cmd := exec.Command(toolPath, toolArgs...)
+    cmd.Stdin = os.Stdin
+    cmd.Stdout = os.Stdout
+    cmd.Stderr = os.Stderr
+    err := cmd.Run()
+    elapsed := time.Since(start)
+    status := exitStatus(err)
+
+    // Best-effort logging that doesn't affect the build
+    _ = logInvocation(tool, toolPath, details, status, elapsed, args)
+
+    os.Exit(status)
+}
+
+func exitStatus(err error) int {
+    if err == nil {
+        return 0
+    }
+    // If it's an *ExitError, use its code; otherwise 1
+    if ee, ok := err.(*exec.ExitError); ok {
+        if ws, ok := ee.Sys().(interface{ ExitStatus() int }); ok {
+            return ws.ExitStatus()
+        }
+    }
+    return 1
+}
+
+type parsedArgs struct {
+    Pkg         string            `json:"pkg"`
+    Out         string            `json:"out"`
+    ImportCfg   string            `json:"importcfg"`
+    EmbedCfg    string            `json:"embedcfg"`
+    BuildID     string            `json:"buildid"`
+    GoVersion   string            `json:"goversion"`
+    Lang        string            `json:"lang"`
+    Concurrency int               `json:"concurrency"`
+    Complete    bool              `json:"complete"`
+    Pack        bool              `json:"pack"`
+    SourceCount int               `json:"source_count"`
+    Flags       map[string]string `json:"flags"`
+}
+
+func parseToolArgs(tool string, toolArgs []string) parsedArgs {
+    d := parsedArgs{Flags: map[string]string{}}
+    for i := 0; i < len(toolArgs); i++ {
+        a := toolArgs[i]
+        if !strings.HasPrefix(a, "-") {
+            d.SourceCount++
+            continue
+        }
+        key := a
+        val := ""
+        if eq := strings.IndexByte(a, '='); eq >= 0 {
+            key = a[:eq]
+            val = a[eq+1:]
+        } else {
+            if i+1 < len(toolArgs) && !strings.HasPrefix(toolArgs[i+1], "-") {
+                val = toolArgs[i+1]
+                i++
+            }
+        }
+        for strings.HasPrefix(key, "-") {
+            key = key[1:]
+        }
+        switch key {
+        case "p":
+            d.Pkg = val
+        case "o":
+            d.Out = val
+        case "importcfg":
+            d.ImportCfg = val
+        case "embedcfg":
+            d.EmbedCfg = val
+        case "buildid":
+            d.BuildID = val
+        case "goversion":
+            d.GoVersion = val
+        case "lang":
+            d.Lang = val
+        case "c":
+            if n, err := strconv.Atoi(val); err == nil {
+                d.Concurrency = n
+            }
+        case "complete":
+            d.Complete = true
+        case "pack":
+            d.Pack = true
+        default:
+            if val == "" {
+                d.Flags[key] = "true"
+            } else {
+                d.Flags[key] = val
+            }
+        }
+    }
+    return d
+}
+
+func logInvocation(tool, toolPath string, details parsedArgs, status int, elapsed time.Duration, fullArgs []string) error {
+    dbPath := getDBPath()
+    dsn := dbPath + "?_pragma=journal_mode(WAL)&_pragma=busy_timeout=5000"
+    db, err := sql.Open("sqlite", dsn)
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    defer db.Close()
+
+    if err := ensureSchema(db); err != nil {
+        return errors.WithStack(err)
+    }
+
+    // Determine run_id from env
+    runID, hasRun := currentRunID()
+
+    // Insert invocation row
+    argsJoined := strings.Join(fullArgs, " ")
+    ts := time.Now().Unix()
+    goos := runtime.GOOS
+    goarch := runtime.GOARCH
+    cwd, _ := os.Getwd()
+    flagsJSON := ""
+    if b, err := json.Marshal(details); err == nil {
+        flagsJSON = string(b)
+    }
+
+    if hasRun {
+        _, err = db.Exec(`
+INSERT INTO invocations (
+  run_id, ts_unix, tool, tool_path, pkg, status, elapsed_ms, args,
+  os, arch, cwd,
+  out, importcfg, embedcfg, buildid, goversion, lang, concurrency, complete, pack, source_count, flags_json
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`, runID, ts, tool, toolPath, details.Pkg, status, elapsed.Milliseconds(), argsJoined,
+            goos, goarch, cwd,
+            details.Out, details.ImportCfg, details.EmbedCfg, details.BuildID, details.GoVersion, details.Lang, details.Concurrency, boolToInt(details.Complete), boolToInt(details.Pack), details.SourceCount, flagsJSON)
+    } else {
+        _, err = db.Exec(`
+INSERT INTO invocations (
+  ts_unix, tool, tool_path, pkg, status, elapsed_ms, args,
+  os, arch, cwd,
+  out, importcfg, embedcfg, buildid, goversion, lang, concurrency, complete, pack, source_count, flags_json
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+`, ts, tool, toolPath, details.Pkg, status, elapsed.Milliseconds(), argsJoined,
+            goos, goarch, cwd,
+            details.Out, details.ImportCfg, details.EmbedCfg, details.BuildID, details.GoVersion, details.Lang, details.Concurrency, boolToInt(details.Complete), boolToInt(details.Pack), details.SourceCount, flagsJSON)
+    }
+    if err != nil {
+        return errors.WithStack(err)
+    }
+    return nil
+}
+
+func boolToInt(b bool) int { if b { return 1 }; return 0 }
+
+

--- a/go.mod
+++ b/go.mod
@@ -112,6 +112,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/client-go v0.29.1
+    modernc.org/sqlite v1.30.1
 )
 
 require (


### PR DESCRIPTION
- Introduce a Go Build Analyzer tool for logging and analyzing Go tool 
  invocations.
- Implement a toolexec wrapper for logging build processes to SQLite without 
  affecting build outcomes.
- Provide a command-line interface (CLI) for querying build runs and 
  invocations.
- Support structured output formats (table, JSON, YAML, CSV) using Glazed 
  commands.
- Include scripts for quick setup, running instrumented builds, and querying 
  results.
- Create a detailed README with usage instructions, prerequisites, and demos.