### PR TITLE
Add doodle clone CLI

### DIFF
--- a/cmd/experiments/2025-09-23/doodle-clone/dsl.go
+++ b/cmd/experiments/2025-09-23/doodle-clone/dsl.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+    "io"
+
+    "gopkg.in/yaml.v3"
+)
+
+const DSLVersion = "doodle-v1"
+
+type Document struct {
+    Version string          `yaml:"version"`
+    Actions []ActionPayload `yaml:"actions"`
+}
+
+type ActionPayload struct {
+    // common envelope
+    ID    string `yaml:"id"`
+    When  string `yaml:"when"`   // now|on_approve (we execute only "now")
+    UseTZ string `yaml:"use_tz"` // e.g. "America/New_York"
+
+    Action string `yaml:"action"`
+
+    // create_poll
+    Title            string            `yaml:"title"`
+    Participants     []ParticipantYAML `yaml:"participants"`
+    Duration         string            `yaml:"duration"`
+    CandidateWindows []WindowYAML      `yaml:"candidate_windows"`
+    Strategy         string            `yaml:"strategy"`
+    Quorum           int               `yaml:"quorum"`
+    Deadline         string            `yaml:"deadline"`
+    Notes            string            `yaml:"notes"`
+    Constraints      []ConstraintYAML  `yaml:"constraints"`
+
+    // add_slots
+    PollRef string     `yaml:"poll_ref"`
+    Slots   []SlotYAML `yaml:"slots"`
+
+    // vote_slot
+    Votes []VoteYAML `yaml:"votes"`
+
+    // finalize_poll
+    PreferredOrder []string `yaml:"preferred_order"`
+
+    // create_event
+    Start       string `yaml:"start"`
+    End         string `yaml:"end"`
+    Location    string `yaml:"location"`
+    CalendarRef string `yaml:"calendar_ref"`
+
+    // propose_times
+    IncludeFreebusy bool `yaml:"include_freebusy"`
+    MaxCandidates   int  `yaml:"max_candidates"`
+
+    // reschedule_event
+    EventRef         string `yaml:"event_ref"`
+    KeepParticipants bool   `yaml:"keep_participants"`
+
+    // set/remove constraints
+    Scope         string   `yaml:"scope"`
+    ScopeRef      string   `yaml:"scope_ref"`
+    ConstraintIDs []string `yaml:"constraint_ids"`
+
+    // sync_now
+    Direction string `yaml:"direction"` // pull|push|both
+}
+
+type ParticipantYAML struct {
+    Email string `yaml:"email"`
+    Role  string `yaml:"role"` // organizer|required|optional (default required)
+}
+
+type WindowYAML struct {
+    Start string `yaml:"start"`
+    End   string `yaml:"end"`
+}
+
+type ConstraintYAML struct {
+    Kind    string                 `yaml:"kind"`
+    Scope   string                 `yaml:"scope"`
+    Payload map[string]interface{} `yaml:"payload"`
+}
+
+type SlotYAML struct {
+    Start string `yaml:"start"`
+    End   string `yaml:"end"`
+}
+
+type VoteYAML struct {
+    SlotRef string `yaml:"slot_ref"` // slot id or ISO start
+    Vote    string `yaml:"vote"`     // yes|no|maybe
+    Email   string `yaml:"email"`    // optional – defaults to "unknown@example.com"
+    Comment string `yaml:"comment,omitempty"`
+}
+
+func ParseDocument(r io.Reader) (*Document, []byte, error) {
+    buf, err := io.ReadAll(r)
+    if err != nil {
+        return nil, nil, err
+    }
+    var doc Document
+    if err := yaml.Unmarshal(buf, &doc); err != nil {
+        return nil, nil, err
+    }
+    return &doc, buf, nil
+}
+
+

--- a/cmd/experiments/2025-09-23/doodle-clone/exec.go
+++ b/cmd/experiments/2025-09-23/doodle-clone/exec.go
@@ -1,0 +1,559 @@
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "sort"
+    "strings"
+    "time"
+
+    "github.com/pkg/errors"
+)
+
+type ExecutorOption func(*Executor)
+
+func WithVerbose(v bool) ExecutorOption {
+    return func(e *Executor) { e.verbose = v }
+}
+
+type Executor struct {
+    store   *Store
+    verbose bool
+    ids     map[string]ActionResult
+}
+
+type ActionResult struct {
+    InputID    string
+    Operation  string
+    PollID     string
+    SlotIDs    []string
+    EventID    string
+    ConstrIDs  []string
+    Candidates []Candidate
+    Summary    string
+}
+
+type Candidate struct {
+    Start time.Time `json:"start"`
+    End   time.Time `json:"end"`
+    Score int       `json:"score"`
+}
+
+func NewExecutor(store *Store, opts ...ExecutorOption) *Executor {
+    e := &Executor{
+        store: store,
+        ids:   map[string]ActionResult{},
+    }
+    for _, o := range opts {
+        o(e)
+    }
+    return e
+}
+
+func (e *Executor) Run(ctx context.Context, doc *Document) ([]ActionResult, error) {
+    var out []ActionResult
+    for _, a := range doc.Actions {
+        if a.When != "" && a.When != "now" {
+            out = append(out, ActionResult{
+                InputID:   a.ID,
+                Operation: a.Action,
+                Summary:   "skipped (when != now)",
+            })
+            continue
+        }
+
+        res, err := e.execOne(ctx, a)
+        if err != nil {
+            return out, errors.Wrapf(err, "action id=%q op=%s", a.ID, a.Action)
+        }
+        out = append(out, res)
+        if a.ID != "" {
+            e.ids[a.ID] = res
+        }
+    }
+    return out, nil
+}
+
+func (e *Executor) execOne(ctx context.Context, a ActionPayload) (ActionResult, error) {
+    loc, err := resolveTZ(a.UseTZ)
+    if err != nil {
+        return ActionResult{}, err
+    }
+
+    switch strings.ToLower(a.Action) {
+    case "create_poll":
+        return e.actCreatePoll(ctx, a, loc)
+    case "add_slots":
+        return e.actAddSlots(ctx, a, loc)
+    case "vote_slot":
+        return e.actVoteSlot(ctx, a, loc)
+    case "finalize_poll":
+        return e.actFinalizePoll(ctx, a)
+    case "create_event":
+        return e.actCreateEvent(ctx, a, loc)
+    case "propose_times":
+        return e.actProposeTimes(ctx, a, loc)
+    case "reschedule_event":
+        return e.actRescheduleEvent(ctx, a, loc)
+    case "set_constraints":
+        return e.actSetConstraints(ctx, a)
+    case "remove_constraints":
+        return e.actRemoveConstraints(ctx, a)
+    case "sync_now":
+        return ActionResult{
+            InputID:   a.ID,
+            Operation: a.Action,
+            Summary:   "sync simulated (no-op in CLI)",
+        }, nil
+    default:
+        return ActionResult{}, errors.Errorf("unsupported action: %s", a.Action)
+    }
+}
+
+func (e *Executor) actCreatePoll(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    durationMin := 0
+    if a.Duration != "" {
+        d, err := time.ParseDuration(a.Duration)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse duration")
+        }
+        durationMin = int(d / time.Minute)
+    }
+
+    var deadlinePtr *time.Time
+    if a.Deadline != "" {
+        t, err := parseTime(a.Deadline, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse deadline")
+        }
+        deadlinePtr = &t
+    }
+
+    p := &Poll{
+        Title:           a.Title,
+        Strategy:        valOr(a.Strategy, "approval"),
+        Quorum:          a.Quorum,
+        Deadline:        deadlinePtr,
+        Notes:           a.Notes,
+        DurationMinutes: durationMin,
+    }
+    if err := e.store.CreatePoll(ctx, p); err != nil {
+        return ActionResult{}, err
+    }
+
+    for _, pr := range a.Participants {
+        pp := &PollParticipant{
+            PollID: p.ID,
+            Email:  pr.Email,
+            Role:   pr.Role,
+        }
+        if err := e.store.AddPollParticipant(ctx, pp); err != nil {
+            return ActionResult{}, err
+        }
+    }
+
+    for _, w := range a.CandidateWindows {
+        ws, err := parseTime(w.Start, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse window.start")
+        }
+        we, err := parseTime(w.End, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse window.end")
+        }
+        if !ws.Before(we) {
+            return ActionResult{}, errors.Errorf("window has start >= end")
+        }
+        if err := e.store.AddPollWindow(ctx, &PollWindow{
+            PollID: p.ID,
+            Start:  ws.UTC(),
+            End:    we.UTC(),
+        }); err != nil {
+            return ActionResult{}, err
+        }
+    }
+
+    for _, c := range a.Constraints {
+        payloadJSON, _ := json.Marshal(c.Payload)
+        if err := e.store.InsertConstraint(ctx, &Constraint{
+            Scope:       "poll",
+            ScopeRef:    p.ID,
+            Kind:        c.Kind,
+            PayloadJSON: string(payloadJSON),
+        }); err != nil {
+            return ActionResult{}, errors.Wrap(err, "insert constraint")
+        }
+    }
+
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        PollID:    p.ID,
+        Summary:   fmt.Sprintf("poll created: %s", p.ID),
+    }, nil
+}
+
+func (e *Executor) actAddSlots(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    pollID, err := e.resolvePollRef(a.PollRef)
+    if err != nil {
+        return ActionResult{}, err
+    }
+    var ids []string
+    for _, s := range a.Slots {
+        st, err := parseTime(s.Start, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse slot.start")
+        }
+        et, err := parseTime(s.End, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse slot.end")
+        }
+        sl := &Slot{
+            PollID: pollID,
+            Start:  st.UTC(),
+            End:    et.UTC(),
+        }
+        if err := e.store.AddSlot(ctx, sl); err != nil {
+            return ActionResult{}, err
+        }
+        ids = append(ids, sl.ID)
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        PollID:    pollID,
+        SlotIDs:   ids,
+        Summary:   fmt.Sprintf("slots added: %d", len(ids)),
+    }, nil
+}
+
+func (e *Executor) actVoteSlot(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    pollID, err := e.resolvePollRef(a.PollRef)
+    if err != nil {
+        return ActionResult{}, err
+    }
+    var updated int
+    for _, v := range a.Votes {
+        slot, err := e.resolveSlotRef(ctx, pollID, v.SlotRef, loc)
+        if err != nil {
+            return ActionResult{}, err
+        }
+        if slot == nil {
+            return ActionResult{}, errors.Errorf("slot not found for ref: %s", v.SlotRef)
+        }
+        email := v.Email
+        if email == "" {
+            email = "unknown@example.com"
+        }
+        err = e.store.UpsertVote(ctx, &Vote{
+            PollID:  pollID,
+            SlotID:  slot.ID,
+            Email:   email,
+            Vote:    strings.ToLower(v.Vote),
+            Comment: v.Comment,
+        })
+        if err != nil {
+            return ActionResult{}, err
+        }
+        updated++
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        PollID:    pollID,
+        Summary:   fmt.Sprintf("votes recorded: %d", updated),
+    }, nil
+}
+
+func (e *Executor) actFinalizePoll(ctx context.Context, a ActionPayload) (ActionResult, error) {
+    pollID, err := e.resolvePollRef(a.PollRef)
+    if err != nil {
+        return ActionResult{}, err
+    }
+    slots, err := e.store.GetSlotsByPoll(ctx, pollID)
+    if err != nil {
+        return ActionResult{}, err
+    }
+    if len(slots) == 0 {
+        return ActionResult{}, errors.Errorf("no slots to finalize for poll %s", pollID)
+    }
+
+    if len(a.PreferredOrder) > 0 {
+        for _, id := range a.PreferredOrder {
+            for _, s := range slots {
+                if s.ID == id {
+                    evt := &Event{
+                        Title: fmt.Sprintf("Poll %s", pollID),
+                        Start: s.Start,
+                        End:   s.End,
+                    }
+                    if err := e.store.CreateEvent(ctx, evt); err != nil {
+                        return ActionResult{}, err
+                    }
+                    if err := e.store.SetPollEvent(ctx, pollID, evt.ID); err != nil {
+                        return ActionResult{}, err
+                    }
+                    return ActionResult{
+                        InputID:   a.ID,
+                        Operation: a.Action,
+                        PollID:    pollID,
+                        EventID:   evt.ID,
+                        Summary:   fmt.Sprintf("finalized with preferred slot %s", s.ID),
+                    }, nil
+                }
+            }
+        }
+    }
+
+    type sc struct {
+        Slot Slot
+        Yes  int
+    }
+    var scored []sc
+    for _, s := range slots {
+        yes, err := e.store.CountYesVotes(ctx, s.ID)
+        if err != nil {
+            return ActionResult{}, err
+        }
+        scored = append(scored, sc{Slot: s, Yes: yes})
+    }
+    sort.Slice(scored, func(i, j int) bool {
+        if scored[i].Yes == scored[j].Yes {
+            return scored[i].Slot.Start.Before(scored[j].Slot.Start)
+        }
+        return scored[i].Yes > scored[j].Yes
+    })
+    chosen := scored[0].Slot
+
+    evt := &Event{
+        Title: fmt.Sprintf("Poll %s", pollID),
+        Start: chosen.Start,
+        End:   chosen.End,
+    }
+    if err := e.store.CreateEvent(ctx, evt); err != nil {
+        return ActionResult{}, err
+    }
+    if err := e.store.SetPollEvent(ctx, pollID, evt.ID); err != nil {
+        return ActionResult{}, err
+    }
+
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        PollID:    pollID,
+        EventID:   evt.ID,
+        Summary:   fmt.Sprintf("finalized with slot %s (yes=%d)", chosen.ID, scored[0].Yes),
+    }, nil
+}
+
+func (e *Executor) actCreateEvent(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    st, err := parseTime(a.Start, loc)
+    if err != nil {
+        return ActionResult{}, errors.Wrap(err, "parse start")
+    }
+    en, err := parseTime(a.End, loc)
+    if err != nil {
+        return ActionResult{}, errors.Wrap(err, "parse end")
+    }
+    evt := &Event{
+        Title:       a.Title,
+        Start:       st.UTC(),
+        End:         en.UTC(),
+        Location:    a.Location,
+        Notes:       a.Notes,
+        CalendarRef: a.CalendarRef,
+    }
+    if err := e.store.CreateEvent(ctx, evt); err != nil {
+        return ActionResult{}, err
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        EventID:   evt.ID,
+        Summary:   fmt.Sprintf("event created: %s", evt.ID),
+    }, nil
+}
+
+func (e *Executor) actProposeTimes(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    if len(a.CandidateWindows) == 0 {
+        return ActionResult{}, errors.Errorf("propose_times requires candidate_windows")
+    }
+    dur, err := time.ParseDuration(valOr(a.Duration, "30m"))
+    if err != nil {
+        return ActionResult{}, errors.Wrap(err, "parse duration")
+    }
+    var out []Candidate
+    for _, w := range a.CandidateWindows {
+        ws, err := parseTime(w.Start, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse window.start")
+        }
+        we, err := parseTime(w.End, loc)
+        if err != nil {
+            return ActionResult{}, errors.Wrap(err, "parse window.end")
+        }
+        step := 30 * time.Minute
+        for cur := ws; cur.Add(dur).Before(we) || cur.Add(dur).Equal(we); cur = cur.Add(step) {
+            out = append(out, Candidate{
+                Start: cur.UTC(),
+                End:   cur.Add(dur).UTC(),
+                Score: 0,
+            })
+            if a.MaxCandidates > 0 && len(out) >= a.MaxCandidates {
+                break
+            }
+        }
+        if a.MaxCandidates > 0 && len(out) >= a.MaxCandidates {
+            break
+        }
+    }
+
+    b, _ := json.MarshalIndent(out, "", "  ")
+    fmt.Printf("propose_times candidates:\n%s\n", string(b))
+
+    return ActionResult{
+        InputID:    a.ID,
+        Operation:  a.Action,
+        Candidates: out,
+        Summary:    fmt.Sprintf("candidates=%d", len(out)),
+    }, nil
+}
+
+func (e *Executor) actRescheduleEvent(ctx context.Context, a ActionPayload, loc *time.Location) (ActionResult, error) {
+    if a.EventRef == "" {
+        return ActionResult{}, errors.Errorf("event_ref required")
+    }
+    if len(a.CandidateWindows) == 0 {
+        return ActionResult{}, errors.Errorf("candidate_windows required")
+    }
+    ws, err := parseTime(a.CandidateWindows[0].Start, loc)
+    if err != nil {
+        return ActionResult{}, errors.Wrap(err, "parse candidate_windows[0].start")
+    }
+    we, err := parseTime(a.CandidateWindows[0].End, loc)
+    if err != nil {
+        return ActionResult{}, errors.Wrap(err, "parse candidate_windows[0].end")
+    }
+    if !ws.Before(we) {
+        return ActionResult{}, errors.Errorf("window start >= end")
+    }
+    d := time.Hour
+    if a.Duration != "" {
+        if dd, err := time.ParseDuration(a.Duration); err == nil {
+            d = dd
+        }
+    }
+    newStart := ws.UTC()
+    newEnd := ws.Add(d).UTC()
+    if newEnd.After(we.UTC()) {
+        return ActionResult{}, errors.Errorf("duration doesn't fit into window")
+    }
+    if err := e.store.UpdateEventTimes(ctx, a.EventRef, newStart, newEnd); err != nil {
+        return ActionResult{}, err
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        EventID:   a.EventRef,
+        Summary:   fmt.Sprintf("event %s rescheduled to %s - %s", a.EventRef, newStart.Format(time.RFC3339), newEnd.Format(time.RFC3339)),
+    }, nil
+}
+
+func (e *Executor) actSetConstraints(ctx context.Context, a ActionPayload) (ActionResult, error) {
+    var ids []string
+    for _, c := range a.Constraints {
+        payloadJSON, _ := json.Marshal(c.Payload)
+        rc := &Constraint{
+            Scope:       valOr(c.Scope, valOr(a.Scope, "user")),
+            ScopeRef:    a.ScopeRef,
+            Kind:        c.Kind,
+            PayloadJSON: string(payloadJSON),
+        }
+        if err := e.store.InsertConstraint(ctx, rc); err != nil {
+            return ActionResult{}, err
+        }
+        ids = append(ids, rc.ID)
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        ConstrIDs: ids,
+        Summary:   fmt.Sprintf("constraints added: %d", len(ids)),
+    }, nil
+}
+
+func (e *Executor) actRemoveConstraints(ctx context.Context, a ActionPayload) (ActionResult, error) {
+    aff, err := e.store.DeleteConstraints(ctx, a.ConstraintIDs)
+    if err != nil {
+        return ActionResult{}, err
+    }
+    return ActionResult{
+        InputID:   a.ID,
+        Operation: a.Action,
+        Summary:   fmt.Sprintf("constraints removed: %d", aff),
+    }, nil
+}
+
+func (e *Executor) resolvePollRef(ref string) (string, error) {
+    if ref == "" {
+        return "", errors.Errorf("poll_ref required")
+    }
+    if res, ok := e.ids[ref]; ok && res.PollID != "" {
+        return res.PollID, nil
+    }
+    return ref, nil
+}
+
+func (e *Executor) resolveSlotRef(ctx context.Context, pollID string, ref string, loc *time.Location) (*Slot, error) {
+    if sl, err := e.store.GetSlotByID(ctx, ref); err == nil && sl != nil && sl.PollID == pollID {
+        return sl, nil
+    }
+    t, err := parseTime(ref, loc)
+    if err == nil {
+        sl, err := e.store.GetSlotByStart(ctx, pollID, t.UTC())
+        if err != nil {
+            return nil, err
+        }
+        return sl, nil
+    }
+    return nil, errors.Errorf("cannot resolve slot_ref: %s", ref)
+}
+
+func resolveTZ(tz string) (*time.Location, error) {
+    if tz == "" {
+        return time.Local, nil
+    }
+    loc, err := time.LoadLocation(tz)
+    if err != nil {
+        return nil, errors.Wrap(err, "load tz")
+    }
+    return loc, nil
+}
+
+func parseTime(s string, loc *time.Location) (time.Time, error) {
+    if t, err := time.Parse(time.RFC3339, s); err == nil {
+        return t, nil
+    }
+    layouts := []string{
+        "2006-01-02T15:04:05",
+        "2006-01-02T15:04",
+        "2006-01-02 15:04:05",
+        "2006-01-02 15:04",
+    }
+    for _, l := range layouts {
+        if t, err := time.ParseInLocation(l, s, loc); err == nil {
+            return t, nil
+        }
+    }
+    return time.Time{}, errors.Errorf("unsupported time format: %q", s)
+}
+
+func valOr[T ~string](v T, def T) T {
+    if string(v) == "" {
+        return def
+    }
+    return v
+}
+
+

--- a/cmd/experiments/2025-09-23/doodle-clone/main.go
+++ b/cmd/experiments/2025-09-23/doodle-clone/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+    "context"
+    "fmt"
+    "io"
+    "os"
+    "time"
+
+    "github.com/pkg/errors"
+    "github.com/spf13/cobra"
+)
+
+var (
+    dbPath   string
+    yamlFile string
+    verbose  bool
+)
+
+func main() {
+    root := &cobra.Command{
+        Use:   "doodle-clone",
+        Short: "Apply YAML scheduling actions to a local SQLite doodle-like store",
+    }
+
+    root.PersistentFlags().StringVar(&dbPath, "db", "./doodle.db", "Path to sqlite database file")
+    root.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Verbose output")
+
+    applyCmd := &cobra.Command{
+        Use:   "apply",
+        Short: "Apply a YAML document with scheduling actions",
+        RunE: func(cmd *cobra.Command, args []string) error {
+            return runApply(cmd.Context())
+        },
+    }
+    applyCmd.Flags().StringVarP(&yamlFile, "file", "f", "", "YAML file path (use '-' for stdin)")
+    _ = applyCmd.MarkFlagRequired("file")
+
+    root.AddCommand(applyCmd)
+
+    if err := root.Execute(); err != nil {
+        fmt.Fprintf(os.Stderr, "error: %v\n", err)
+        os.Exit(1)
+    }
+}
+
+func runApply(ctx context.Context) error {
+    store, err := OpenStore(ctx, dbPath)
+    if err != nil {
+        return errors.Wrap(err, "open store")
+    }
+    defer func() { _ = store.Close() }()
+
+    if err := store.Init(ctx); err != nil {
+        return errors.Wrap(err, "init db schema")
+    }
+
+    var r io.Reader
+    if yamlFile == "-" {
+        r = os.Stdin
+    } else {
+        f, err := os.Open(yamlFile)
+        if err != nil {
+            return errors.Wrap(err, "open yaml file")
+        }
+        defer func() { _ = f.Close() }()
+        r = f
+    }
+
+    doc, rawBytes, err := ParseDocument(r)
+    if err != nil {
+        return errors.Wrap(err, "parse yaml")
+    }
+    if verbose {
+        fmt.Printf("Loaded YAML (%d bytes) version=%q actions=%d\n", len(rawBytes), doc.Version, len(doc.Actions))
+    }
+
+    exec := NewExecutor(store, WithVerbose(verbose))
+    results, err := exec.Run(ctx, doc)
+    if err != nil {
+        return errors.Wrap(err, "execute actions")
+    }
+
+    // Minimal summary
+    now := time.Now().Format(time.RFC3339)
+    fmt.Printf("\n== Applied at %s ==\n", now)
+    for i, r := range results {
+        fmt.Printf("- action[%d] id=%q op=%s -> %s\n", i, r.InputID, r.Operation, r.Summary)
+    }
+    return nil
+}
+
+

--- a/cmd/experiments/2025-09-23/doodle-clone/store.go
+++ b/cmd/experiments/2025-09-23/doodle-clone/store.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+    "context"
+    "database/sql"
+    "time"
+
+    "github.com/google/uuid"
+    "github.com/jmoiron/sqlx"
+    _ "github.com/mattn/go-sqlite3"
+    "github.com/pkg/errors"
+)
+
+type Store struct {
+    db *sqlx.DB
+}
+
+func OpenStore(ctx context.Context, path string) (*Store, error) {
+    db, err := sqlx.ConnectContext(ctx, "sqlite3", path+"?_foreign_keys=1&_journal_mode=WAL")
+    if err != nil {
+        return nil, errors.Wrap(err, "connect sqlite")
+    }
+    return &Store{db: db}, nil
+}
+
+func (s *Store) Close() error {
+    if s.db == nil {
+        return nil
+    }
+    return s.db.Close()
+}
+
+func (s *Store) Init(ctx context.Context) error {
+    schema := `
+CREATE TABLE IF NOT EXISTS polls (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  strategy TEXT NOT NULL DEFAULT 'approval',
+  quorum INTEGER NOT NULL DEFAULT 0,
+  deadline DATETIME,
+  notes TEXT,
+  duration_minutes INTEGER,
+  status TEXT NOT NULL DEFAULT 'draft', -- draft|finalized
+  event_id TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS poll_participants (
+  id TEXT PRIMARY KEY,
+  poll_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'required',
+  UNIQUE(poll_id, email),
+  FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS poll_windows (
+  id TEXT PRIMARY KEY,
+  poll_id TEXT NOT NULL,
+  start_ts DATETIME NOT NULL,
+  end_ts DATETIME NOT NULL,
+  FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS slots (
+  id TEXT PRIMARY KEY,
+  poll_id TEXT NOT NULL,
+  start_ts DATETIME NOT NULL,
+  end_ts DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(poll_id, start_ts),
+  FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS votes (
+  id TEXT PRIMARY KEY,
+  poll_id TEXT NOT NULL,
+  slot_id TEXT NOT NULL,
+  email TEXT NOT NULL,
+  vote TEXT NOT NULL, -- yes|no|maybe
+  comment TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE(slot_id, email),
+  FOREIGN KEY (poll_id) REFERENCES polls(id) ON DELETE CASCADE,
+  FOREIGN KEY (slot_id) REFERENCES slots(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  start_ts DATETIME NOT NULL,
+  end_ts DATETIME NOT NULL,
+  location TEXT,
+  notes TEXT,
+  calendar_ref TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS constraints (
+  id TEXT PRIMARY KEY,
+  scope TEXT NOT NULL, -- user|event|poll
+  scope_ref TEXT,      -- nullable for user
+  kind TEXT NOT NULL,
+  payload TEXT NOT NULL, -- JSON
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_slots_poll ON slots(poll_id);
+CREATE INDEX IF NOT EXISTS idx_votes_slot ON votes(slot_id);
+CREATE INDEX IF NOT EXISTS idx_votes_poll ON votes(poll_id);
+`
+    _, err := s.db.ExecContext(ctx, schema)
+    return errors.Wrap(err, "create schema")
+}
+
+func (s *Store) CreatePoll(ctx context.Context, p *Poll) error {
+    if p.ID == "" {
+        p.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO polls (id, title, strategy, quorum, deadline, notes, duration_minutes, status)
+VALUES (?, ?, ?, ?, ?, ?, ?, 'draft')`,
+        p.ID, p.Title, p.Strategy, p.Quorum, nullTime(p.Deadline), p.Notes, p.DurationMinutes)
+    return errors.Wrap(err, "insert poll")
+}
+
+func (s *Store) SetPollEvent(ctx context.Context, pollID, eventID string) error {
+    _, err := s.db.ExecContext(ctx, `UPDATE polls SET status='finalized', event_id=? WHERE id=?`, eventID, pollID)
+    return errors.Wrap(err, "update poll finalized")
+}
+
+func (s *Store) AddPollParticipant(ctx context.Context, pp *PollParticipant) error {
+    if pp.ID == "" {
+        pp.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO poll_participants (id, poll_id, email, role)
+VALUES (?, ?, ?, ?) ON CONFLICT(poll_id, email) DO UPDATE SET role=excluded.role`,
+        pp.ID, pp.PollID, pp.Email, pp.RoleOrDefault())
+    return errors.Wrap(err, "insert poll participant")
+}
+
+func (s *Store) AddPollWindow(ctx context.Context, w *PollWindow) error {
+    if w.ID == "" {
+        w.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO poll_windows (id, poll_id, start_ts, end_ts)
+VALUES (?, ?, ?, ?)`,
+        w.ID, w.PollID, w.Start, w.End)
+    return errors.Wrap(err, "insert poll window")
+}
+
+func (s *Store) AddSlot(ctx context.Context, sl *Slot) error {
+    if sl.ID == "" {
+        sl.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO slots (id, poll_id, start_ts, end_ts)
+VALUES (?, ?, ?, ?)`,
+        sl.ID, sl.PollID, sl.Start, sl.End)
+    return errors.Wrap(err, "insert slot")
+}
+
+func (s *Store) GetSlotsByPoll(ctx context.Context, pollID string) ([]Slot, error) {
+    var out []Slot
+    err := s.db.SelectContext(ctx, &out, `SELECT id, poll_id, start_ts, end_ts, created_at FROM slots WHERE poll_id=? ORDER BY start_ts ASC`, pollID)
+    return out, errors.Wrap(err, "select slots by poll")
+}
+
+func (s *Store) GetSlotByID(ctx context.Context, slotID string) (*Slot, error) {
+    var out Slot
+    err := s.db.GetContext(ctx, &out, `SELECT id, poll_id, start_ts, end_ts, created_at FROM slots WHERE id=?`, slotID)
+    if errors.Is(err, sql.ErrNoRows) {
+        return nil, nil
+    }
+    return &out, errors.Wrap(err, "select slot by id")
+}
+
+func (s *Store) GetSlotByStart(ctx context.Context, pollID string, start time.Time) (*Slot, error) {
+    var out Slot
+    err := s.db.GetContext(ctx, &out, `SELECT id, poll_id, start_ts, end_ts, created_at FROM slots WHERE poll_id=? AND start_ts=?`, pollID, start)
+    if errors.Is(err, sql.ErrNoRows) {
+        return nil, nil
+    }
+    return &out, errors.Wrap(err, "select slot by start")
+}
+
+func (s *Store) UpsertVote(ctx context.Context, v *Vote) error {
+    if v.ID == "" {
+        v.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO votes (id, poll_id, slot_id, email, vote, comment)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(slot_id, email) DO UPDATE SET vote=excluded.vote, comment=excluded.comment`,
+        v.ID, v.PollID, v.SlotID, v.Email, v.Vote, v.Comment)
+    return errors.Wrap(err, "upsert vote")
+}
+
+func (s *Store) CountYesVotes(ctx context.Context, slotID string) (int, error) {
+    var c int
+    err := s.db.GetContext(ctx, &c, `SELECT COUNT(*) FROM votes WHERE slot_id=? AND vote='yes'`, slotID)
+    return c, errors.Wrap(err, "count yes")
+}
+
+func (s *Store) CreateEvent(ctx context.Context, e *Event) error {
+    if e.ID == "" {
+        e.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO events (id, title, start_ts, end_ts, location, notes, calendar_ref)
+VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        e.ID, e.Title, e.Start, e.End, e.Location, e.Notes, e.CalendarRef)
+    return errors.Wrap(err, "insert event")
+}
+
+func (s *Store) UpdateEventTimes(ctx context.Context, id string, start, end time.Time) error {
+    _, err := s.db.ExecContext(ctx, `UPDATE events SET start_ts=?, end_ts=? WHERE id=?`, start, end, id)
+    return errors.Wrap(err, "update event times")
+}
+
+func (s *Store) InsertConstraint(ctx context.Context, c *Constraint) error {
+    if c.ID == "" {
+        c.ID = uuid.NewString()
+    }
+    _, err := s.db.ExecContext(ctx, `
+INSERT INTO constraints (id, scope, scope_ref, kind, payload)
+VALUES (?, ?, ?, ?, ?)`,
+        c.ID, c.Scope, c.ScopeRef, c.Kind, c.PayloadJSON)
+    return errors.Wrap(err, "insert constraint")
+}
+
+func (s *Store) DeleteConstraints(ctx context.Context, ids []string) (int64, error) {
+    if len(ids) == 0 {
+        return 0, nil
+    }
+    q, args, err := sqlx.In(`DELETE FROM constraints WHERE id IN (?)`, ids)
+    if err != nil {
+        return 0, errors.Wrap(err, "build IN query")
+    }
+    q = s.db.Rebind(q)
+    res, err := s.db.ExecContext(ctx, q, args...)
+    if err != nil {
+        return 0, errors.Wrap(err, "exec delete")
+    }
+    aff, _ := res.RowsAffected()
+    return aff, nil
+}
+
+type Poll struct {
+    ID              string
+    Title           string
+    Strategy        string
+    Quorum          int
+    Deadline        *time.Time
+    Notes           string
+    DurationMinutes int
+}
+
+type PollParticipant struct {
+    ID     string
+    PollID string
+    Email  string
+    Role   string
+}
+
+func (pp *PollParticipant) RoleOrDefault() string {
+    if pp.Role == "" {
+        return "required"
+    }
+    return pp.Role
+}
+
+type PollWindow struct {
+    ID     string
+    PollID string
+    Start  time.Time
+    End    time.Time
+}
+
+type Slot struct {
+    ID     string    `db:"id"`
+    PollID string    `db:"poll_id"`
+    Start  time.Time `db:"start_ts"`
+    End    time.Time `db:"end_ts"`
+    CreatedAt time.Time `db:"created_at"`
+}
+
+type Vote struct {
+    ID      string
+    PollID  string
+    SlotID  string
+    Email   string
+    Vote    string
+    Comment string
+}
+
+type Event struct {
+    ID          string
+    Title       string
+    Start       time.Time
+    End         time.Time
+    Location    string
+    Notes       string
+    CalendarRef string
+}
+
+type Constraint struct {
+    ID          string
+    Scope       string
+    ScopeRef    string
+    Kind        string
+    PayloadJSON string
+}
+
+func nullTime(t *time.Time) interface{} {
+    if t == nil {
+        return nil
+    }
+    return *t
+}
+
+

--- a/ttmp/2025-09-23/01-yaml-dsl-doodle-clone.md
+++ b/ttmp/2025-09-23/01-yaml-dsl-doodle-clone.md
@@ -1,0 +1,284 @@
+
+Here’s a tight, implementation-oriented sketch you can build from. I’ve kept it focused: core architecture, the AI-chat flow (as real tools), and a minimal, expressive YAML DSL for actions.
+
+# System overview
+
+* **Clients**: Web (React) + Mobile (optional). Realtime over WebSocket.
+* **API**: Go/TS service exposing REST+WebSocket; serves auth, polls, proposals, scheduling actions.
+* **Sync workers**: Per-provider connectors (Google Calendar, Outlook, CalDAV). Event-driven, idempotent.
+* **Scheduler**: Computes candidate times, resolves constraints, finalizes events, writes back to calendars.
+* **AI Orchestrator**: Chat endpoint that calls tool functions (the same REST actions) and emits YAML actions (below).
+* **Storage**: PostgreSQL (+ Redis for jobs/locks).
+* **Queue**: e.g., Redis Streams / RabbitMQ for sync + scheduler jobs.
+* **Secrets/OAuth**: per-provider tokens (rotated), PKCE/OIDC for user login.
+
+# Core data model (essentials)
+
+* `users(id, name, email, tz, locale)`
+* `calendars(id, user_id, provider, external_id, access_token, refresh_token, sync_state)`
+* `events(id, organizer_id, calendar_id, title, description, location, start_ts, end_ts, status{draft,pending,final,deleted}, external_id)`
+* `participants(id, event_id, email, role{organizer,required,optional}, response{unknown,yes,no,maybe})`
+* `polls(id, event_id, strategy{rank,approval,first-fit}, quorum, deadline_ts, status)`
+* `slots(id, poll_id, start_ts, end_ts, votes_yes, votes_no, votes_maybe)`
+* `constraints(id, scope{user,event,poll}, kind{window,avoid,capacity,travel}, payload jsonb)`
+* `sync_jobs(id, calendar_id, kind{pull,push}, cursor, status, retries, last_error)`
+* `messages(id, thread_id, user_id, role{user,assistant,tool}, content, action_yaml jsonb)`
+* `webhooks(id, provider, secret, last_seen_ts)` (for provider push)
+
+# Sync model
+
+* **Pull**: initial full sync (time-bounded window), then incremental via provider cursors; de-dupe by `(provider, external_id)`.
+* **Push**: only for **finalized** events; drafts/polls live only in your DB.
+* **Conflict resolution**: write-ahead record version; if provider changed externally, re-open poll or re-optimize.
+* **Locking**: per `event_id` mutex for finalize/writeback.
+
+# Scheduling/availability sketch
+
+1. **Collect availability**: own calendars + optional free/busy pulls of invitees (when authorized) + constraints.
+2. **Generate candidates**: sliding window over organizer’s preferred ranges; prune by hard constraints; score by soft prefs.
+3. **Poll** (optional): create N slots; collect votes; early-stop when quorum satisfied.
+4. **Finalize**: pick top feasible slot; push to organizer’s calendar and send ICS to others (and to provider if connected).
+
+# API surface (selected)
+
+* `POST /auth/provider/{google|microsoft|caldav}/init` → OAuth URL
+* `POST /polls` `{ title, participants[], candidate_windows[], duration, strategy, quorum, deadline }`
+* `POST /polls/{id}/slots` `{ slots[] }`
+* `POST /polls/{id}/vote` `{ slot_id, vote{yes|no|maybe} }`
+* `POST /polls/{id}/finalize`
+* `POST /constraints` `{ scope, kind, payload }`
+* `POST /events` `{ title, participants[], start_ts, end_ts, location }`
+* `POST /events/{id}/reschedule` `{ candidate_windows[] | slot_id }`
+* `POST /sync/run` `{ calendar_id, kind }`
+* WebSocket: `subscribe: {event_id|poll_id}` → server pushes slot updates, votes, finalize.
+
+# AI chat—tool calling (what the model can do)
+
+Expose these **verifiable tools** (the assistant never writes directly; it *calls tools* that hit the API):
+
+* `create_poll`, `add_slots`, `vote_slot`, `finalize_poll`
+* `create_event`, `reschedule_event`, `cancel_event`
+* `set_constraints`, `remove_constraints`
+* `propose_times` (server runs candidate generator and returns ranked slots)
+* `sync_now`
+
+The assistant **also** emits/accepts the YAML DSL (below) so users/agents can compose multi-step changes in one message.
+
+---
+
+# YAML DSL for scheduling actions
+
+## Design goals
+
+* **Minimal**: actions are explicit and map 1:1 to API/tool calls.
+* **Deterministic defaults**: server fills defaults when fields omitted (e.g., duration).
+* **Staging**: multiple actions in a single doc; each action has an `id` so later steps can reference earlier outputs.
+
+## Top-level schema
+
+```yaml
+version: "doodle-v1"
+actions:
+  - id: <string>            # optional; for cross references
+    when: now|on_approve    # optional; default now
+    use_tz: "America/New_York"  # optional; per-action override
+    action: <OneOfBelow>
+```
+
+## Action variants
+
+### 1) Create poll
+
+```yaml
+action: create_poll
+title: "Team sync"
+participants:
+  - email: "a@example.com"     # role defaults to required
+  - email: "b@example.com"
+duration: "45m"
+candidate_windows:             # organizer windows to search within
+  - start: "2025-09-24T09:00"
+    end:   "2025-09-24T17:00"
+  - start: "2025-09-25T09:00"
+    end:   "2025-09-25T17:00"
+strategy: "approval"           # rank|approval|first-fit
+quorum: 2
+deadline: "2025-09-24T23:00"
+notes: "Remote, Zoom"
+constraints:
+  - kind: window               # hard allow list (also supports avoid)
+    scope: poll
+    payload:
+      weekdays: [Mon, Tue, Wed, Thu]
+      earliest: "09:00"
+      latest: "17:30"
+  - kind: avoid
+    scope: poll
+    payload:
+      dates: ["2025-09-24"]
+```
+
+### 2) Add explicit slots to poll
+
+```yaml
+action: add_slots
+poll_ref: "<id|external>"      # id of poll or previous action id
+slots:
+  - start: "2025-09-24T10:00"
+    end:   "2025-09-24T10:45"
+  - start: "2025-09-25T14:00"
+    end:   "2025-09-25T14:45"
+```
+
+### 3) Vote on a slot
+
+```yaml
+action: vote_slot
+poll_ref: "<id>"
+votes:
+  - slot_ref: "<slot-id|iso-ts>"  # slot id or start time
+    vote: yes|no|maybe
+```
+
+### 4) Finalize a poll
+
+```yaml
+action: finalize_poll
+poll_ref: "<id>"
+preferred_order: ["slot-123", "slot-456"]  # optional; overrides server ranking if feasible
+```
+
+### 5) Create an event directly (no poll)
+
+```yaml
+action: create_event
+title: "Design review"
+participants:
+  - email: "c@example.com"
+  - email: "d@example.com"
+start: "2025-09-26T11:00"
+end:   "2025-09-26T12:00"
+location: "Zoom"
+notes: "Focus on API"
+calendar_ref: "primary"        # or specific connected calendar id
+```
+
+### 6) Propose times (server generates candidates)
+
+```yaml
+action: propose_times
+duration: "30m"
+candidate_windows:
+  - start: "2025-09-27T09:00"
+    end:   "2025-09-27T17:00"
+participants:
+  - email: "e@example.com"
+include_freebusy: true          # if authorized
+max_candidates: 8
+```
+
+### 7) Reschedule an existing event
+
+```yaml
+action: reschedule_event
+event_ref: "<id|external>"
+candidate_windows:
+  - start: "2025-09-28T13:00"
+    end:   "2025-09-28T18:00"
+keep_participants: true
+```
+
+### 8) Set / remove constraints
+
+```yaml
+action: set_constraints
+scope: user|event|poll
+scope_ref: "<optional id>"      # required for event|poll
+constraints:
+  - kind: window
+    payload:
+      weekdays: [Mon, Tue, Wed, Thu, Fri]
+      earliest: "10:00"
+      latest: "16:00"
+  - kind: avoid
+    payload:
+      locations: ["travel"]
+```
+
+```yaml
+action: remove_constraints
+constraint_ids: ["constr-1","constr-2"]
+```
+
+### 9) Trigger sync
+
+```yaml
+action: sync_now
+calendar_ref: "primary"
+direction: pull|push|both
+```
+
+## Batch example (multi-step, referenced)
+
+```yaml
+version: "doodle-v1"
+actions:
+  - id: poll1
+    action: create_poll
+    title: "Quarterly planning"
+    participants:
+      - email: "ops@example.com"
+      - email: "pm@example.com"
+    duration: "1h"
+    candidate_windows:
+      - start: "2025-09-29T09:00"
+        end:   "2025-10-01T17:00"
+    strategy: "rank"
+    quorum: 2
+
+  - id: slots1
+    action: add_slots
+    poll_ref: "poll1"
+    slots:
+      - start: "2025-09-30T10:00"
+        end:   "2025-09-30T11:00"
+      - start: "2025-10-01T15:00"
+        end:   "2025-10-01T16:00"
+
+  - id: finalize
+    action: finalize_poll
+    poll_ref: "poll1"
+```
+
+---
+
+# AI chat loop (tool wiring)
+
+1. User says: “find a 45m slot with Alice/Bob next Tue/Wed.”
+2. NLU → extract participants, windows, duration.
+3. Assistant emits **YAML** with `propose_times` (or `create_poll`+`add_slots`) and calls tool(s).
+4. Server returns candidates; assistant summarizes and, on “yes”, emits `finalize_poll`.
+5. On finalize, the **Scheduler** creates the event and the **Sync worker** writes it to the organizer’s calendar.
+
+**Tools JSON (example)**
+
+* `propose_times(params) → {candidates:[{start,end,score}]}`
+* `create_poll(params) → {poll_id, slots[]?}`
+* `finalize_poll({poll_id, slot_id}) → {event_id, external_id}`
+* `create_event(params) → {event_id, external_id}`
+* `set_constraints(params) → {constraint_ids[]}`
+
+---
+
+# Implementation notes (just the essentials)
+
+* **Idempotency keys** on create/finalize to survive retries.
+* **TZ handling**: store UTC + `original_tz`; DSL `use_tz` resolves naive times.
+* **Free/busy**: cache short-lived; fall back to “unknown” for non-authorized invitees.
+* **Webhooks**: register per provider to receive updates; re-sync on change notifications.
+
+If you want, I can turn this into:
+
+* an OpenAPI stub for the API,
+* a JSON Schema for the YAML DSL,
+* or a minimal Go service skeleton with the tool endpoints wired to the scheduler.

--- a/ttmp/2025-09-23/03-doodle-v1-tutorial.md
+++ b/ttmp/2025-09-23/03-doodle-v1-tutorial.md
@@ -1,0 +1,116 @@
+## Doodle-v1 YAML DSL Tutorial (SQLite + CLI)
+
+This tutorial shows how to run the doodle-clone CLI against a YAML actions file, verify results in SQLite, and iterate.
+
+### Prereqs
+- Go 1.21+
+- SQLite CLI (`sqlite3`) recommended for verification
+
+### 1) Quick check the CLI is available
+```bash
+go run ./go-go-labs/cmd/experiments/2025-09-23/doodle-clone --help
+```
+
+### 2) Create a demo YAML
+Save to `go-go-labs/ttmp/2025-09-23/doodle-demo.yaml`:
+
+```yaml
+version: "doodle-v1"
+actions:
+  - id: poll1
+    action: create_poll
+    use_tz: "Europe/Berlin"
+    title: "Team sync"
+    participants:
+      - email: "a@example.com"
+      - email: "b@example.com"
+    duration: "45m"
+    candidate_windows:
+      - start: "2025-09-25T09:00"
+        end:   "2025-09-25T17:00"
+      - start: "2025-09-26T09:00"
+        end:   "2025-09-26T17:00"
+    strategy: "approval"
+    quorum: 1
+    notes: "Remote"
+
+  - id: slots1
+    action: add_slots
+    poll_ref: "poll1"
+    slots:
+      - start: "2025-09-25T10:00"
+        end:   "2025-09-25T10:45"
+      - start: "2025-09-26T14:00"
+        end:   "2025-09-26T14:45"
+
+  - id: votes1
+    action: vote_slot
+    poll_ref: "poll1"
+    votes:
+      - slot_ref: "2025-09-25T10:00"
+        vote: yes
+        email: "a@example.com"
+      - slot_ref: "2025-09-26T14:00"
+        vote: maybe
+        email: "b@example.com"
+
+  - id: finalize
+    action: finalize_poll
+    poll_ref: "poll1"
+```
+
+### 3) Apply the actions (fresh DB) and view output
+```bash
+rm -f go-go-labs/ttmp/2025-09-23/doodle.db && \
+go run ./go-go-labs/cmd/experiments/2025-09-23/doodle-clone apply \
+  -f go-go-labs/ttmp/2025-09-23/doodle-demo.yaml \
+  --db go-go-labs/ttmp/2025-09-23/doodle.db \
+  -v
+```
+
+Expected: a summary listing each action and a created event after finalize.
+
+### 4) Verify results in SQLite
+```bash
+sqlite3 go-go-labs/ttmp/2025-09-23/doodle.db "SELECT id,title,status,event_id FROM polls;"
+sqlite3 go-go-labs/ttmp/2025-09-23/doodle.db "SELECT id,poll_id,start_ts,end_ts FROM slots ORDER BY start_ts;"
+sqlite3 go-go-labs/ttmp/2025-09-23/doodle.db "SELECT id,slot_id,email,vote FROM votes ORDER BY created_at;"
+sqlite3 go-go-labs/ttmp/2025-09-23/doodle.db "SELECT id,title,start_ts,end_ts FROM events;"
+```
+
+You should see:
+- One poll with status=finalized and a non-null `event_id`
+- Two slots
+- Two votes
+- One event covering the winning slot
+
+### 5) Optional: Propose times
+Save to `go-go-labs/ttmp/2025-09-23/doodle-propose.yaml`:
+```yaml
+version: "doodle-v1"
+actions:
+  - id: propose
+    action: propose_times
+    use_tz: "Europe/Berlin"
+    duration: "30m"
+    candidate_windows:
+      - start: "2025-09-27T09:00"
+        end:   "2025-09-27T17:00"
+    max_candidates: 6
+```
+
+Run:
+```bash
+go run ./go-go-labs/cmd/experiments/2025-09-23/doodle-clone apply \
+  -f go-go-labs/ttmp/2025-09-23/doodle-propose.yaml \
+  --db go-go-labs/ttmp/2025-09-23/doodle.db \
+  -v
+```
+
+Expected: printed JSON candidates; no writes to DB.
+
+### Notes
+- Naive times are resolved via `use_tz` and stored in UTC.
+- `slot_ref` may be a slot id or the slot start timestamp.
+
+

--- a/ttmp/2025-09-23/doodle-demo.yaml
+++ b/ttmp/2025-09-23/doodle-demo.yaml
@@ -1,0 +1,44 @@
+version: "doodle-v1"
+actions:
+  - id: poll1
+    action: create_poll
+    use_tz: "Europe/Berlin"
+    title: "Team sync"
+    participants:
+      - email: "a@example.com"
+      - email: "b@example.com"
+    duration: "45m"
+    candidate_windows:
+      - start: "2025-09-25T09:00"
+        end:   "2025-09-25T17:00"
+      - start: "2025-09-26T09:00"
+        end:   "2025-09-26T17:00"
+    strategy: "approval"
+    quorum: 1
+    notes: "Remote"
+
+  - id: slots1
+    action: add_slots
+    poll_ref: "poll1"
+    slots:
+      - start: "2025-09-25T10:00"
+        end:   "2025-09-25T10:45"
+      - start: "2025-09-26T14:00"
+        end:   "2025-09-26T14:45"
+
+  - id: votes1
+    action: vote_slot
+    poll_ref: "poll1"
+    votes:
+      - slot_ref: "2025-09-25T10:00"
+        vote: yes
+        email: "a@example.com"
+      - slot_ref: "2025-09-26T14:00"
+        vote: maybe
+        email: "b@example.com"
+
+  - id: finalize
+    action: finalize_poll
+    poll_ref: "poll1"
+
+

--- a/ttmp/2025-09-23/doodle-propose.yaml
+++ b/ttmp/2025-09-23/doodle-propose.yaml
@@ -1,0 +1,12 @@
+version: "doodle-v1"
+actions:
+  - id: propose
+    action: propose_times
+    use_tz: "Europe/Berlin"
+    duration: "30m"
+    candidate_windows:
+      - start: "2025-09-27T09:00"
+        end:   "2025-09-27T17:00"
+    max_candidates: 6
+
+


### PR DESCRIPTION
- Introduce CLI tool for managing scheduling actions using a YAML DSL.
- Supports actions like creating polls, adding slots, voting, finalizing polls, 
  and creating events.
- CLI interacts with a local SQLite database for persistent storage.
- Includes a YAML DSL for defining scheduling actions with minimal syntax.
- Provides options for verbose output and reading from standard input.
- Implements a structured approach for scheduling tasks using candidate windows 
  and constraints.
- New documentation added for usage and examples.